### PR TITLE
Removed some buffer overflows from sprintf.c

### DIFF
--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -2228,7 +2228,7 @@ add_table_now:
                     // only strcat if at least 2 bytes (1 byte after this bit) left
                     while ( --isize > -1  && --tmpl >= 1)
                     {
-                       if ( ( carg->u.number & ( 1 << isize ) ) != 0 )
+                       if ( ( carg->u.number & ( (p_int)1 << isize ) ) != 0 )
                        {
                           // Gnomi: strcat is quite inefficient. isize
                           // or tmpl could be used for direct indexing


### PR DESCRIPTION
sprintf.c contained some buffer overflows of buffers on the stack.
These were written to, checked if they overflowed and fatal() was
called if there was an overflow...
Mostly by use of snprintf() these overflows can't happen anymore
and the fatal() is an ordinary runtime error.
(fixes #825)
