### PR TITLE
Default types for functions

### DIFF
--- a/src/prolang.y
+++ b/src/prolang.y
@@ -3916,14 +3916,22 @@ define_new_function ( Bool complete, ident_t *p, int num_arg, int num_local
                 }
 #               undef TYPE_MOD_VIS
 
-                /* Check if the 'varargs' attribute is conserved, when pedantic. */
-                if (pragma_pedantic
-                 && (funp->flags ^ flags) & TYPE_MOD_VARARGS
-                 &&  funp->flags & TYPE_MOD_VARARGS
+                /* Check if the 'varargs' attribute is conserved. */
+                if ((old_fflags ^ flags) & TYPE_MOD_VARARGS
+                    &&  old_fflags & TYPE_MOD_VARARGS
                    )
                 {
-                    yywarnf("Redefinition of '%s' loses 'varargs' modifier."
-                           , get_txt(p->name));
+                    // this is a warning in case of re-defining inherited functions
+                    // with pedantic, but always an error when prototype->definition
+                    if (old_fflags & NAME_INHERITED)
+                    {
+                        if (pragma_check_overloads)
+                            yywarnf("Redefinition of '%s' loses 'varargs' modifier."
+                                    , get_txt(p->name));
+                    }
+                    else
+                        yyerrorf("Inconsistent declaration of '%s': 'varargs' modifier lost."
+                                , get_txt(p->name));
                 }
 
                 /* Check that the two argument lists are compatible */

--- a/src/prolang.y
+++ b/src/prolang.y
@@ -3867,11 +3867,11 @@ define_new_function ( Bool complete, ident_t *p, int num_arg, int num_local
                 // Then check the number of arguments and varargs flags and determine
                 // if we should check the argument types (later).
                 if (funp->num_arg > num_arg && !(funp->flags & TYPE_MOD_VARARGS))
-                    yyerrorf("Incorrect number of arguments in redefinition of '%s'.", get_txt(p->name));
+                    yyerrorf("Incorrect number of arguments in redefinition of '%s'", get_txt(p->name));
                 else if (funp->num_arg == num_arg
                       && ((funp->flags ^ flags) & TYPE_MOD_XVARARGS)
                       && !(funp->flags & TYPE_MOD_VARARGS))
-                    yyerrorf("Incorrect number of arguments in redefinition of '%s'.", get_txt(p->name));
+                    yyerrorf("Incorrect number of arguments in redefinition of '%s'", get_txt(p->name));
                 else
                 {
                     unsigned short first_arg;
@@ -3881,7 +3881,7 @@ define_new_function ( Bool complete, ident_t *p, int num_arg, int num_local
                     {
                         if (num_arg && !(funp->flags & NAME_TYPES_LOST) )
                             yyerrorf(
-                              "Redefined function '%s' not compiled with type testing."
+                              "Redefined function '%s' not compiled with type testing"
                             , get_txt(p->name));
                     }
                     else
@@ -3926,11 +3926,11 @@ define_new_function ( Bool complete, ident_t *p, int num_arg, int num_local
                     if (old_fflags & NAME_INHERITED)
                     {
                         if (pragma_check_overloads)
-                            yywarnf("Redefinition of '%s' loses 'varargs' modifier."
+                            yywarnf("Redefinition of '%s' loses 'varargs' modifier"
                                     , get_txt(p->name));
                     }
                     else
-                        yyerrorf("Inconsistent declaration of '%s': 'varargs' modifier lost."
+                        yyerrorf("Inconsistent declaration of '%s': 'varargs' modifier lost"
                                 , get_txt(p->name));
                 }
 

--- a/src/prolang.y
+++ b/src/prolang.y
@@ -3895,32 +3895,26 @@ define_new_function ( Bool complete, ident_t *p, int num_arg, int num_local
                  * visibility is conserved. For redefining inherited functions
                  * different visibility is OK.
                  */
+#               define TYPE_MOD_VIS \
+                        ( TYPE_MOD_NO_MASK \
+                        | TYPE_MOD_PRIVATE | TYPE_MOD_PUBLIC \
+                        |TYPE_MOD_STATIC | TYPE_MOD_PROTECTED)
+
+                if (!(old_fflags & (NAME_INHERITED|NAME_TYPES_LOST))
+                    && ((new_fflags ^ old_fflags) & TYPE_MOD_VIS)
+                    )
                 {
-#                   define TYPE_MOD_VIS \
-                           ( TYPE_MOD_NO_MASK \
-                           | TYPE_MOD_PRIVATE | TYPE_MOD_PUBLIC \
-                           | TYPE_MOD_PROTECTED)
-
-                    /* Smooth out irrelevant differences */
-                    if (new_fflags & TYPE_MOD_STATIC) new_fflags |= TYPE_MOD_PROTECTED;
-                    if (old_fflags & TYPE_MOD_STATIC) old_fflags |= TYPE_MOD_PROTECTED;
-
-                    if (!(old_fflags & (NAME_INHERITED|NAME_TYPES_LOST))
-                        && ((new_fflags ^ old_fflags) & TYPE_MOD_VIS)
-                       )
-                    {
-                        char buff[120];
-                        strncpy(buff, get_f_visibility(old_fflags), sizeof(buff)-1);
-                        buff[sizeof(buff) - 1] = '\0'; // strncpy() does not guarantee NUL-termination
-                        if (pragma_pedantic)
-                            yyerrorf("Inconsistent declaration of '%s': Visibility changed from '%s' to '%s'"
-                                    , get_txt(p->name), buff, get_visibility(type));
-                        else
-                            yywarnf("Inconsistent declaration of '%s': Visibility changed from '%s' to '%s'"
-                                    , get_txt(p->name), buff, get_visibility(type));
-                    }
-#                   undef TYPE_MOD_VIS
+                    char buff[120];
+                    strncpy(buff, get_f_visibility(old_fflags), sizeof(buff)-1);
+                    buff[sizeof(buff) - 1] = '\0'; // strncpy() does not guarantee NUL-termination
+                    if (pragma_pedantic)
+                        yyerrorf("Inconsistent declaration of '%s': Visibility changed from '%s' to '%s'"
+                                , get_txt(p->name), buff, get_visibility(type));
+                    else
+                        yywarnf("Inconsistent declaration of '%s': Visibility changed from '%s' to '%s'"
+                                , get_txt(p->name), buff, get_visibility(type));
                 }
+#               undef TYPE_MOD_VIS
 
                 /* Check if the 'varargs' attribute is conserved, when pedantic. */
                 if (pragma_pedantic

--- a/src/prolang.y
+++ b/src/prolang.y
@@ -3892,7 +3892,8 @@ define_new_function ( Bool complete, ident_t *p, int num_arg, int num_local
                 } /* cases (number of arguments) */
 
                 /* If it's a prototype->function redefinition, check if the
-                 * visibility is conserved.
+                 * visibility is conserved. For redefining inherited functions
+                 * different visibility is OK.
                  */
                 {
 #                   define TYPE_MOD_VIS \
@@ -3905,15 +3906,18 @@ define_new_function ( Bool complete, ident_t *p, int num_arg, int num_local
                     if (old_fflags & TYPE_MOD_STATIC) old_fflags |= TYPE_MOD_PROTECTED;
 
                     if (!(old_fflags & (NAME_INHERITED|NAME_TYPES_LOST))
-                     && ((new_fflags ^ old_fflags) & TYPE_MOD_VIS)
+                        && ((new_fflags ^ old_fflags) & TYPE_MOD_VIS)
                        )
                     {
                         char buff[120];
-
                         strncpy(buff, get_f_visibility(old_fflags), sizeof(buff)-1);
                         buff[sizeof(buff) - 1] = '\0'; // strncpy() does not guarantee NUL-termination
-                        yywarnf("Inconsistent declaration of '%s': Visibility changed from '%s' to '%s'"
-                               , get_txt(p->name), buff, get_visibility(type));
+                        if (pragma_pedantic)
+                            yyerrorf("Inconsistent declaration of '%s': Visibility changed from '%s' to '%s'"
+                                    , get_txt(p->name), buff, get_visibility(type));
+                        else
+                            yywarnf("Inconsistent declaration of '%s': Visibility changed from '%s' to '%s'"
+                                    , get_txt(p->name), buff, get_visibility(type));
                     }
 #                   undef TYPE_MOD_VIS
                 }


### PR DESCRIPTION
Solves Bug #837 and may prevent some other NULL pointer dereferences.
Does also improve errors/warnings concerning the handling of prototypes + defintions.
