### PR TITLE
Relax float format inside mappings for restore_value()

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -7170,12 +7170,13 @@ restore_map_size (struct rms_parameters *parameters)
                 pt2 = strpbrk(pt, "=:;,");
                 if (!pt2)
                     return -1;
-                if (*pt2 != '=')
-                    break;
-                pt = strchr(pt2, ':');
-                if (!pt)
-                    return -1;
-                pt++;
+                if (*pt2 == '=')
+                {
+                    pt = strchr(pt2, ':');
+                    if (!pt)
+                        return -1;
+                    pt++;
+                }
             }
             /* FALL THROUGH */
 

--- a/test/t-efuns.c
+++ b/test/t-efuns.c
@@ -234,6 +234,8 @@ mixed *tests = ({
         (: restore_value(save_value(__FLOAT_MAX__)) == __FLOAT_MAX__ :) }),
     ({ "save_/restore_value 2", 0, 
         (: restore_value(save_value(__FLOAT_MIN__)) == __FLOAT_MIN__ :) }),
+    ({ "save_/restore_value 3", 0,
+        (: restore_value("([2.0:2.0,])\n")[2.0] == 2.0 :) }),
     ({ "sort_array 1", 0, (: deep_eq(sort_array(({4,5,2,6,1,3,0}),#'>),
                                      ({0,1,2,3,4,5,6})) :) }),
     ({ "sort_array 2", 0, // sort in-place


### PR DESCRIPTION
This allows `restore_value("([2.0:2.0,])\n")`. Note that close variants
like `restore_value("([22.0:-22.0,])\n")` already work.

The current behavior doesn't look intentional to me: in case a float is found that is not followed by an equality sign, there is a `break` statement, but if an error was intended, that should be `return -1`.
