### PR TITLE
#763 Added pragma warn_rtt_checks to downgrade rtt errors to warnings

### DIFF
--- a/doc/3.3vs3.5/language
+++ b/doc/3.3vs3.5/language
@@ -122,6 +122,8 @@ that you should pay attention to when updating.
     always give information about the context of an error.
     This pragma is ignored  (#702)
   + The pragma warn_deprecated is now enabled by default. (#702)
+  + The new pragma warn_rtt_checks shows runtime type errors
+    as warnings (#763)
 
 - 'deprecated' modifier
   The deprecated modifier can be used for lfuns (and sefuns) and global

--- a/doc/LPC/pragma
+++ b/doc/LPC/pragma
@@ -33,6 +33,8 @@ DESCRIPTION
                 check at compile time.
                 strong_types/strict_types is seriously recommended.
                 This pragma implicitly enables save_types as well.
+        warn_rtt_checks: runtime checks are enabled, just like rtt_checks,
+                but errors will be shown as warnings only.
         no_rtt_checks: disable runtime type checks for this program (default).
 
         pedantic: Certain warnings are treated as errors:

--- a/src/exec.h
+++ b/src/exec.h
@@ -562,6 +562,7 @@ enum program_flags {
     P_SHARE_VARIABLES = 0x0010, /* Clone vars are assigned from 
                                  * the current blueprint vars. */
     P_RTT_CHECKS      = 0x0020, /* enable runtime type checks */
+    P_WARN_RTT_CHECKS = 0x0040, /* enable runtime type check warnings */
 };
 /* Special value for type_start in program_s designating that the function has
  * no type info. */

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -191,6 +191,7 @@
 #include "typedefs.h"
 
 #include "my-alloca.h"
+#include <assert.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -6719,6 +6720,9 @@ check_function_args(int fx, program_t *progp, bytecode_p funstart)
             // or is the formal argument of type TYPE_ANY (mixed)?
             if (!check_rtt_compatibility(arg_type[i], firstarg+i))
             {
+                // How many control stack frames to remove.
+                int num_csf = 0;
+
                 // Determine the lpctype of arg_type[i] for a better error message.
                 static char buff[512];
                 lpctype_t *realtype = get_rtt_type(arg_type[i], firstarg+i);
@@ -6732,12 +6736,12 @@ check_function_args(int fx, program_t *progp, bytecode_p funstart)
                 if (csp > CONTROL_STACK + 1)
                 {
                     // at least 3 frames on the stack. We can get rid of at least one of them.
-                    pop_control_stack();
+                    num_csf++;
                     // int_call_lambda() pushes a dummy control frame with funstart==0. This
                     // has to removed as well if existing.
                     // (Assumption: there are not other control stack frames with funstart==0.)
-                    if (!csp->funstart)
-                        pop_control_stack();
+                    if (!csp[-1].funstart)
+                        num_csf++;
                 }
                 else if (csp == CONTROL_STACK + 1)
                 {
@@ -6747,7 +6751,7 @@ check_function_args(int fx, program_t *progp, bytecode_p funstart)
                     // start of a top-level evaluation and both frames have to remain.
                     // In that case, we have to set inter_pc to a valid value.
                     if (CONTROL_STACK->funstart)
-                        pop_control_stack();
+                        num_csf++;
                     else
                         inter_pc = funstart;
                 }
@@ -6758,10 +6762,41 @@ check_function_args(int fx, program_t *progp, bytecode_p funstart)
                     // or it is a left-over from last execution.
                     inter_pc = funstart;
                 }
-                // unravel any lvalue indirection (if any)
-                errorf("Bad arg %d to %s(): got '%s', expected '%s'.\n"
-                       , i+1, get_txt(header->name), buff,
-                       get_lpctype_name(arg_type[i]));
+
+                if (progp->flags & P_WARN_RTT_CHECKS)
+                {
+                    // We need the stack frames to continue execution.
+                    // But now they are in the way of a good error message...
+                    struct control_stack saved_csf[3];
+                    assert(num_csf < 3);
+
+                    push_control_stack(inter_sp, inter_pc, inter_fp, inter_context);
+                    for (int j = 0; j <= num_csf; j++)
+                        saved_csf[j] = *(csp--);
+                    csp++;
+
+                    // This one we saved, but also pull back into reality.
+                    pop_control_stack();
+
+                    // warnf will return (errors are caught).
+                    warnf("Bad arg %d to %s(): got '%s', expected '%s'.\n"
+                           , i+1, get_txt(header->name), buff,
+                           get_lpctype_name(arg_type[i]));
+
+                    for (int j = num_csf; j >= 0; j--)
+                        *(++csp) = saved_csf[j];
+
+                    pop_control_stack();
+                }
+                else
+                {
+                    for (int j = 0; j < num_csf; j++)
+                        pop_control_stack();
+
+                    errorf("Bad arg %d to %s(): got '%s', expected '%s'.\n"
+                           , i+1, get_txt(header->name), buff,
+                           get_lpctype_name(arg_type[i]));
+                }
             }
             ++i;
         }
@@ -9121,7 +9156,12 @@ again:
                 free_lpctype(realtype);
 
                 inter_sp = sp;
-                errorf("Bad return type in %s(): got '%s', expected '%s'.\n",
+                if (current_prog->flags & P_WARN_RTT_CHECKS)
+                    warnf("Bad return type in %s(): got '%s', expected '%s'.\n",
+                       get_txt(header->name), buff,
+                       get_lpctype_name(header->type));
+                else
+                    errorf("Bad return type in %s(): got '%s', expected '%s'.\n",
                        get_txt(header->name), buff,
                        get_lpctype_name(header->type));
             }

--- a/src/lex.c
+++ b/src/lex.c
@@ -199,6 +199,10 @@ Bool pragma_rtt_checks;
   /* True: enable runtime type checks for this program
    */
 
+Bool pragma_warn_rtt_checks;
+  /* True: emit warnings when doing runtime type checks for this program
+   */
+
 string_t *last_lex_string;
   /* When lexing string literals, this is the (shared) string lexed
    * so far. It is used to pass string values to lang.c and may be
@@ -3458,11 +3462,20 @@ handle_pragma (char *str)
         {
             pragma_rtt_checks = MY_TRUE;
             pragma_save_types = MY_TRUE;
+            pragma_warn_rtt_checks = MY_FALSE;
+            validPragma = MY_TRUE;
+        }
+        else if (strncmp(base, "warn_rtt_checks", namelen) == 0)
+        {
+            pragma_rtt_checks = MY_TRUE;
+            pragma_save_types = MY_TRUE;
+            pragma_warn_rtt_checks = MY_TRUE;
             validPragma = MY_TRUE;
         }
         else if (strncmp(base, "no_rtt_checks", namelen) == 0)
         {
             pragma_rtt_checks = MY_FALSE;
+            pragma_warn_rtt_checks = MY_FALSE;
             validPragma = MY_TRUE;
         }
         else if (strncmp(base, "share_variables", namelen) == 0)
@@ -5414,6 +5427,7 @@ start_new_file (int fd, const char * fname)
     pragma_warn_empty_casts = MY_TRUE;
     pragma_share_variables = share_variables;
     pragma_rtt_checks = MY_FALSE;
+    pragma_warn_rtt_checks = MY_FALSE;
 
     nexpands = 0;
 

--- a/src/lex.h
+++ b/src/lex.h
@@ -249,6 +249,7 @@ extern Bool pragma_warn_empty_casts;
 extern Bool pragma_check_overloads;
 extern Bool pragma_share_variables;
 extern Bool pragma_rtt_checks;
+extern Bool pragma_warn_rtt_checks;
 extern string_t *last_lex_string;
 extern ident_t *all_efuns;
 

--- a/src/object.c
+++ b/src/object.c
@@ -8983,13 +8983,21 @@ static int nesting = 0;  /* Used to detect recursive calls */
                 get_lpctype_name_buf(realtype, realtypebuf, sizeof(realtypebuf));
                 free_lpctype(realtype);
 
-                free_svalue(v);
-                *v = const0;
-
-                errorf("Bad type when restoring %s from %s line %d. Expected "
+                if (ob->prog->flags & P_WARN_RTT_CHECKS)
+                    warnf("Bad type when restoring %s from %s line %d. Expected "
                        "%s, got %s.\n",
                        get_txt(current_object->name), name, lineno,
                        get_lpctype_name(vtype.t_type), realtypebuf);
+                else
+                {
+                    free_svalue(v);
+                    *v = const0;
+
+                    errorf("Bad type when restoring %s from %s line %d. Expected "
+                       "%s, got %s.\n",
+                       get_txt(current_object->name), name, lineno,
+                       get_lpctype_name(vtype.t_type), realtypebuf);
+                }
             }
         }
 

--- a/src/prolang.y
+++ b/src/prolang.y
@@ -16771,6 +16771,7 @@ epilog (void)
                     | (pragma_no_shadow ? P_NO_SHADOW : 0)
                     | (pragma_share_variables ? P_SHARE_VARIABLES : 0)
                     | (pragma_rtt_checks ? P_RTT_CHECKS : 0)
+                    | (pragma_warn_rtt_checks ? P_WARN_RTT_CHECKS : 0)
                     ;
 
         prog->load_time = current_time;


### PR DESCRIPTION
The new pragma warn_rtt_checks behaves just like rtt_checks, but shows
runtime type errors as warnings instead of errors (Resolves #763).