### PR TITLE
Correcting spelling mistakes in documentation and output strings

### DIFF
--- a/CHANGELOG.OLD
+++ b/CHANGELOG.OLD
@@ -209,7 +209,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
     a large number of certificates on usual installations (which are not
     related to client certificates) and GnuTLS clients have a problem with
     that (too large handshake data). Whoever wants to use client
-    certificates shall set it up explicitely.
+    certificates shall set it up explicitly.
     (configure)
   - Updated Avalon settings file.
     (settings/avalon)
@@ -488,7 +488,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
 
 10-May-2009 (Zesstra)
   - (smalloc.c, slaballoc.) Replaced SINT by GRANULARITY
-    The define SINT was ill-named. All occurences were renamed to GRANULARITY
+    The define SINT was ill-named. All occurrences were renamed to GRANULARITY
     which describes the semantics of the define much better and it is now
     defined as being sizeof(word_t).
     Additionally, MEM_ALIGN is now defined as being the same as GRANULARITY.
@@ -1290,7 +1290,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
        namespace can get the driver confused with references to
        undefined structs. (Bug #493)
   - (simul_efun.c) If a simul_efun object appeared before being blessed
-       explicitely, it may be an old backup copy. This situation is
+       explicitly, it may be an old backup copy. This situation is
        now rejected as the variable/function definitions may differ
        subtly. (Bug #489)
 
@@ -2207,7 +2207,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
        into the bugtracker.
 
 26-Nov-2004 (Lars Duening)  (3.3.618, .619)
-  - (closure.c) Calls to explicitely inherited lfun closures weren't compiled
+  - (closure.c) Calls to explicitly inherited lfun closures weren't compiled
        correctly in lambda()s (Bug #0000145).
 
 25-Nov-2004 (Lars Duening)  (3.3.617)
@@ -2217,7 +2217,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
 
 24-Nov-2004 (Lars Duening)  (3.3.616)
   - (closure, gcollect.c, interpret.c, object.c prolang) Implemented proper
-       closures explicitely referencing inherited functions.
+       closures explicitly referencing inherited functions.
 
 22-Nov-2004 (Lars Duening)  (3.3.615)
   - (comm.c) Efun net_connect(): on multihomed machines the created
@@ -3211,7 +3211,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
 26-Jul-2003 (Lars Duening)  (3.3.466)
   - (mapping.c) Taking a cue from 3.2.10-594, the number of times a mapping
        is checked for destructed elements has been reduced. This was less of
-       a problem than in 3.2.10, but still occured far too often,
+       a problem than in 3.2.10, but still occurred far too often,
   - (mapping.c) The mapping compaction criterium has been extended to
        guarantee a compaction after 2 * TIME_TO_COMPACT seconds idle time.
 
@@ -4189,7 +4189,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
       every time_to_clean_up seconds (or 3600 seconds if no cleanup
       time is set); active objects are data-cleaned every time
       the processing gets to them.
-  - (swap.c) When swapping strings, the length is now explicitely stored
+  - (swap.c) When swapping strings, the length is now explicitly stored
       in the swap file. The old format added a \0 character as terminator,
       and consequently malfunctioned or crashed on strings using \0 as
       data character.
@@ -4497,7 +4497,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
   - (object.c) Efun inherit_list(): the tagging of virtual inherits
        didn't work (reported by Dafire).
   - (prolang.y) The test for duplicate toplevel inherits got confused
-       when virtual inherits occured (reported by Zonk via Dafire).
+       when virtual inherits occurred (reported by Zonk via Dafire).
 
 18-Sep-2002 (Lars Duening)  (3.3.261)
   - (func_spec, interpret, simulate) Added the infrastructure to create
@@ -4539,7 +4539,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
   - (closure.c) The argument checking when compiling sefuns in a lambda
        closure didn't work properly (reported by Coogan).
   - (exec.h) The mask SEC_TYPE_INFO was defined improperly.
-  - (prolang.y) If an explicite call to an inherited function couldn't
+  - (prolang.y) If an explicit call to an inherited function couldn't
        be compiled, the argument type stack got popped too often - eventually
        causing memory corruption.
 
@@ -4775,7 +4775,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
         create buggy code, so I removed it from the configure.
    - (object.c) Efun tell_room() leaked memory.
    - (simulate.c) check_valid_path() leaked the pathname when
-       an error occured.
+       an error occurred.
 
 14-Aug-2002 (Lars Duening) (3.3.222)
     - (comm.c) Compilation broke under BeOS.
@@ -4802,7 +4802,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
          error codes instead of calling regerror(). This puts it more
          in line with the PCRE implementation.
     - (configure, setting files) PCRE is now compilation default; however
-         I disabled it explicitedly in the setting files.
+         I disabled it explicitly in the setting files.
     - (regexp, pcre) Whenever the RE engine has to backtrack, the eval
          cost is incremented and checked. This will catch pathological
          matches like regexp(({"=XX==================="}), "X(.+)+X")
@@ -5493,7 +5493,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
         mess up the object statistics. As a first measure the GC after
         the mark phase checks the list of destructed objects if any
         of the objects on it haven't been referenced yet. If so, the
-        objects concerned are logged and then explicitely included into
+        objects concerned are logged and then explicitly included into
         the list of objects to free. This way at least the object statistics
         will be kept in sync for the time being.
 
@@ -5592,7 +5592,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
 
 10-Dec-2001 (Lars Duening)  (3.3.137)
     - (interpret.c) gcc 2.91 on Linux/x86 generates buggy code for
-         MIN_INT % -1, so this case is now explicitely check for
+         MIN_INT % -1, so this case is now explicitly check for
          (reported by Menaures).
     - (interpret.c) Multiplication of a string with a number was
          not checked for numeric overflows in the computation of
@@ -6159,7 +6159,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
         arguments, the subsequent argument type checks were wrong
         (reported by Fiona).
     - (sprintf.c) Instead of using the new modifier '$', the efun now
-        uses the existence of an explicite pad string specification
+        uses the existence of an explicit pad string specification
         as flag whether to remove pad space before new lines or not.
         This is actually more logical to use than a modifier (suggested
         by Largo).
@@ -6195,7 +6195,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
          libraries. This might not be fully correct yet.
     - (make_func.y) Removed a couple of warnings under gcc 3.0 (thanks,
         Largo!).
-    - (comm.c) On a regular shutdown, stop the erq demon explicitely.
+    - (comm.c) On a regular shutdown, stop the erq demon explicitly.
     - (main.c) When compiling for MSDOS_FS, the erq pathname wasn't built
         correctly (reported by Coogan).
     - (sprintf.c) Simul-efun closures printed with %O are marked as such.
@@ -6447,7 +6447,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
          from the format string (reported by Robert).
     - (sprintf.c) A leading '0' used to pad the whole field with 0s.
          Now, only leading 0s are printed and this setting and the
-         explicite pad string are independent of each other (suggested
+         explicit pad string are independent of each other (suggested
          by Fiona).
     - (call_out.c) Removing call_outs, or call_outs going stale, messed
          up the 'number of callouts' statistics (provided by Gnomi).
@@ -6752,7 +6752,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
          compilation of prolang.y.
     - (backend.c) Simplified the error message output in write_file().
     - (simulate.c) The master apply runtime_error() receives an extra
-         argument describing if the error is a normal error, or occured
+         argument describing if the error is a normal error, or occurred
          during a heartbeat (suggested by Freaky).
     - (gcollect.c) Added a dump function for closure literals.
     - (lex.c, gcollect.c) Cosmetics.
@@ -7286,7 +7286,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
          efun.
 
 08-Aug-2000 (Lars Duening)
-    - (smalloc.c) Attempts to free a memory block twice are now explicitely
+    - (smalloc.c) Attempts to free a memory block twice are now explicitly
          flagged (when compiling with MALLOC_TRACE).
     - (lex.c) #else and #endif followed by uncommented text raise an error
          only in pedantic mode; otherwise just a warning is generated.
@@ -8038,7 +8038,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
     caused b-991123-0 and b-991123-1 in turn.
     - (comm.c) When accepting a line of non-negotiation text in charmode,
          interactive_t.tn_start became negative after the second char.
-         Similar if an error occured during a very long line - here
+         Similar if an error occurred during a very long line - here
          set_noecho() used wrong indices.
     - (comm.c) Charmode: when a client sent single CRs and there were no
          negotiations on the same line, the CR was re-read (almost)
@@ -8091,7 +8091,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
 
 20-Nov-1999 (Lars Duening)
     - (autoconf/configure.in, configure, port.h) Small tweaks.
-    - (interpret.c) Correction to sort_array(): the GET_NUM_ARG occured
+    - (interpret.c) Correction to sort_array(): the GET_NUM_ARG occurred
          too late.
 
 19-Nov-1999 (Lars Duening)  (3.2.8-dev.156)
@@ -8596,7 +8596,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
 
 29-Jul-1999 (Lars Duening)  (3.2.7-dev.131)
     - (simulate.c) I am surprised nobody complained about this one: when
-        an error occured, the runtime stack was unrolled too early and
+        an error occurred, the runtime stack was unrolled too early and
         left the runtime_error() apply with no valid commandgiver.
     - (func_spec, simulate) New efuns set_limits(), query_limits() and
         limited() to handle runtime limits. (f-981229-11)
@@ -8801,7 +8801,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
     - (machine.h.in, config.h.in, configure, autoconf/) Autoconfiguration
         is now based on autoconf 2. The old configuration code is in the
         subdirectory config-old/ held as backup. Special features are:
-          - rxcache and UDP port can be enabled/disabled explicitely.
+          - rxcache and UDP port can be enabled/disabled explicitly.
           - Enabling ERQ defines a symbol ERQ_INCLUDE pointing to the
             correct include file (util/erq/erq.h resp util/xerq/erq.h).
           - All config.h options can be set using parameters to configure.
@@ -9135,7 +9135,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
         it had to swap it in. This is useful for blueprints for inheritance
         and cloning, which would thrash otherwise. (thanks, Michael!)
     - (lex.c) The test against recursive calls in _expand_define() crashed
-        the driver if an error occured during the macro expansion and the
+        the driver if an error occurred during the macro expansion and the
         error handling itself called macro expansion (e.g. through the
         _expand_define_() efun). For now, non-reentrant recursive calls
         are allowed again.
@@ -9181,7 +9181,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
     - (etc/icon-*.ppm) The Icon for the Gamedriver.
     - (hosts/be/{Makefile, icon-*.raw, driver.r, driver.rscr) Added the
         icon to the compiled resources.
-    - (heartbeat.c) Fixed a crasher which occured when a heart_beat()
+    - (heartbeat.c) Fixed a crasher which occurred when a heart_beat()
         function managed to remove all remaining objects from the hb list.
 
 19-Apr-1999 (Lars Duening)
@@ -9914,7 +9914,7 @@ See the file HISTORY for a user-oriented summary of all the changes.
         cases. Therefore, two DEBUG: messages remain to warn if this
         feature is used.
     - (hosts/be/*) Adapted for R4/x86.
-    - (*.c) Removed most of the 'Possibly unwanted assigment' warnings.
+    - (*.c) Removed most of the 'Possibly unwanted assignment' warnings.
 
 02-Nov-1998 (Lars Duening)
     - (simulate) Corrected bugs in make_name_sane() and load_object().

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -60,7 +60,7 @@ domain.
 All code taken from the MudOS driver is Copyright by Tim Hollebeek and
 the original authors. Use for other purposes than LPmud drivers or under
 licenses significantly different from the original LPmud license needs
-explicite permission.
+explicit permission.
 
 The random() efun is implemented using the SIMD oriented Fast Mersenne 
 Twister (SFMT) which is Copyright (C) 2006, 2007 Mutsuo Saito, Makoto

--- a/HISTORY
+++ b/HISTORY
@@ -900,7 +900,7 @@ For a detailed list of all changes see the file CHANGELOG.
        + The macros __FLOAT_MIN__ and __FLOAT_MAX__ gave a too-small range.
        + New pragma (no_)warn_function_inconsistent to control the handling
          of function redefinitions which differ in return or argument types.
-       + Implemented closures explicitely referencing inherited functions
+       + Implemented closures explicitly referencing inherited functions
            ("#'super::fun").
 
     - Runtime:
@@ -1113,7 +1113,7 @@ For a detailed list of all changes see the file CHANGELOG.
            Single values can be returned instead of the whole array.
        + printf(), sprintf(): A leading zero in the field size will now print
            only leading zeros and not interfere with the pad string option.
-       + printf(), sprintf(): If an explicite pad string is defined, even
+       + printf(), sprintf(): If an explicit pad string is defined, even
            if it is space, the efuns won't remove white space before a line
            end.
        + printf(), sprintf(): Printing numbers with leading zeroes and a
@@ -1368,7 +1368,7 @@ For a detailed list of all changes see the file CHANGELOG.
            name is available in the predefined macro __DEBUG_LOG__.
        + Pragma warn_deprecated causes the compiler to print a warning
            when a deprecated efun is used.
-       + Lfun closures can now explicite name inherited functions
+       + Lfun closures can now explicit name inherited functions
            (#'base::create).
        + Bugfix: Adding mappings of different width throws an error, unless
            one of the mappings if empty.

--- a/doc/LPC/ed2
+++ b/doc/LPC/ed2
@@ -15,7 +15,7 @@ DESCRIPTION
 
         Any character can used instead of '/':
         s!apa!bepa!g
-        The 'g' specifies that all occurences of apa on this line are
+        The 'g' specifies that all occurrences of apa on this line are
         changed to bepa.
 
         The pattern that are supposed to be replaced, can be a regular

--- a/doc/LPC/inline-closures
+++ b/doc/LPC/inline-closures
@@ -64,7 +64,7 @@ DESCRIPTION
                                           { return val * x; };
           }
 
-        These explicite context variables are useful when the closures
+        These explicit context variables are useful when the closures
         needs to keep a state, or to improve performance:
 
           mapping m = ...;

--- a/doc/LPC/modifiers
+++ b/doc/LPC/modifiers
@@ -172,7 +172,7 @@ DESCRIPTION
         (and 'static' for functions only) are allowed here.
 
         The default visibility thus set affects only variables/functions with
-        no explicite visibility:
+        no explicit visibility:
 
           default private;
 

--- a/doc/LPC/operators
+++ b/doc/LPC/operators
@@ -116,7 +116,7 @@ DESCRIPTION
 
         expr1 - expr2        Subtract 'expr2' from 'expr1'. Valid for
                         numbers, strings, arrays, mappings.
-                        For arrays and strings, all occurences of the
+                        For arrays and strings, all occurrences of the
                         elements resp. characters in 'expr2' are removed
                         from 'expr1', and the result is returned.
                         For mapping, all occurances of elemens in 'expr1'

--- a/doc/LPC/types
+++ b/doc/LPC/types
@@ -11,9 +11,9 @@ DESCRIPTION
                 macros __INT_MIN__ and __INT_MAX__.
 
                 Integer values can be specified in decimal, in
-                sedecimal when preceeded by '0x' (e.g. 0x11), binary
+                sedecimal when preceded by '0x' (e.g. 0x11), binary
                 when preceeded by '0b' (e.g. 0b00010001), octal when
-                preceeded by '0o' (e.g. 0o21) and as character
+                preceded by '0o' (e.g. 0o21) and as character
                 yielding the charset value for the character as the number
                 to use (e.g. '0' yields 48 on ASCII machines).
 

--- a/doc/concepts/erq
+++ b/doc/concepts/erq
@@ -343,7 +343,7 @@ DESCRIPTION
                               of two bytes.
             ERQ_E_NSLOTS    : The max number of child processes (given
                               in <info>) is exhausted.
-            ERQ_E_UNKNOWN   : Error <info> occured in one of the system
+            ERQ_E_UNKNOWN   : Error <info> occurred in one of the system
                               calls done to open the port.
 
           Once the port is open, it is treated as if is just another
@@ -418,7 +418,7 @@ DESCRIPTION
                               of two bytes.
             ERQ_E_NSLOTS    : The max number of child processes (given
                               in <info>) is exhausted.
-            ERQ_E_UNKNOWN   : Error <info> occured in one of the system
+            ERQ_E_UNKNOWN   : Error <info> occurred in one of the system
                               calls done to open the port.
 
           Once the port is open, it is treated as if is just another
@@ -445,7 +445,7 @@ DESCRIPTION
                               of two bytes.
             ERQ_E_NSLOTS    : The max number of child processes (given
                               in <info>) is exhausted.
-            ERQ_E_UNKNOWN   : Error <info> occured in one of the system
+            ERQ_E_UNKNOWN   : Error <info> occurred in one of the system
                               calls done to open the port.
 
           Once the port is open, it is treated as if is just another
@@ -539,7 +539,7 @@ DESCRIPTION
             ERQ_E_NSLOTS    : The max number of child processes (given
                               in <info>) is exhausted.
             ERQ_E_TICKET    : the ticket didn't match
-            ERQ_E_UNKNOWN   : Error <info> occured in one of the system
+            ERQ_E_UNKNOWN   : Error <info> occurred in one of the system
                               calls done to open the port.
 
           Once the port is open, it is treated as if it is just another

--- a/doc/driver/invocation
+++ b/doc/driver/invocation
@@ -87,7 +87,7 @@ DESCRIPTION
             List the name of every compiled file on stderr.
 
           -e|--no-preload
-            Pass a non-zero argument (the number of occurences of this option)
+            Pass a non-zero argument (the number of occurrences of this option)
             to master->preload(), which usually inhibits all preloads of
             castles and other objects.
 
@@ -312,7 +312,7 @@ DESCRIPTION
           --args <filename>
             The driver reads and parses the given file and treats its contents
             as if given on the commandline right where the --args option
-            occured. The file itself can again contain --args options.
+            occurred. The file itself can again contain --args options.
 
 
 DESCRIPTION

--- a/doc/efun/db_error
+++ b/doc/efun/db_error
@@ -3,7 +3,7 @@ SYNOPSIS
         string db_error(int handle)
 
 DESCRIPTION
-        Return a string describing the error which occured during the last
+        Return a string describing the error which occurred during the last
         database transaction. If the last database transaction was successful,
         this call returns 0.
 

--- a/doc/efun/dump_driver_info
+++ b/doc/efun/dump_driver_info
@@ -11,7 +11,7 @@ DESCRIPTION
         master->valid_write() to check that it can write
         the files. The file in question is always written anew
 
-        On success the efun returns 1, or 0 if an error occured.
+        On success the efun returns 1, or 0 if an error occurred.
 
         <what> == DDI_OBJECTS:
           Dumps information about all live objects.

--- a/doc/efun/get_error_file
+++ b/doc/efun/get_error_file
@@ -2,11 +2,11 @@ SYNOPSIS
         mixed * get_error_file(string name, int set_forget_flag)
 
 DESCRIPTION
-        Return information about the last error which occured for
+        Return information about the last error which occurred for
         <name> (where <name> is a valid name from the wiz list).
 
         Result is an array of four elements: the filename of the
-        program where the error occured, the linenumber in the
+        program where the error occurred, the linenumber in the
         program, the error message (runtime error messages usually
         start with a '*'), and a numerical flag (the 'forget flag') if
         the error information has been queried already.

--- a/doc/efun/process_string
+++ b/doc/efun/process_string
@@ -3,7 +3,7 @@ SYNOPSIS
         string process_string(string str)
 
 DESCRIPTION
-        Searches string str for occurences of a "value by function
+        Searches string str for occurrences of a "value by function
         call", which is an implicit function call surrounded by @@. See
         "value_by_function_call" in the principles section.
 

--- a/doc/efun/sprintf
+++ b/doc/efun/sprintf
@@ -84,9 +84,9 @@ DESCRIPTION
                 "@") is applied to each element of the array.
 
         When the formatting of an element results in several output lines
-        (column or table mode) and no explicite pad strings has been
+        (column or table mode) and no explicit pad strings has been
         defined, then the efun removes any padding whitespace before
-        the newlines of all but the last line. However, if an explicite
+        the newlines of all but the last line. However, if an explicit
         pad string has been given, even if it is the simple ' ', then
         the padding will not be removed.
 

--- a/doc/efun/write_file
+++ b/doc/efun/write_file
@@ -4,7 +4,7 @@ SYNOPSIS
 
 DESCRIPTION
         Append the string <str> to the file <file>. Returns 1 for success
-        and 0 if any failure occured.
+        and 0 if any failure occurred.
 
         If <flags> is 1, the file is removed first; thus making the
         'append' effectively an 'overwrite'. Default for <flags> is 0.

--- a/doc/internals/codestyle
+++ b/doc/internals/codestyle
@@ -189,7 +189,7 @@ Commenting
          /* long comment which doesn't fit on one line.
           */
 
-    The major steps in a function should be preceeded by a comment
+    The major steps in a function should be preceded by a comment
     explaining them. Also, wherever a critical design decision has
     been made, a comment should line out the whats and whys:
 

--- a/doc/man/ldmud.1
+++ b/doc/man/ldmud.1
@@ -77,7 +77,7 @@ List the name of every compiled file on stderr.
 .HP
 \fB\-e\fR|--no-preload
 .IP
-Pass a non-zero argument (the number of occurences of this option)
+Pass a non-zero argument (the number of occurrences of this option)
 to master->preload(), which usually inhibits all preloads of castles
 and other objects.
 .HP
@@ -200,8 +200,8 @@ or 'unlimited' removes any restriction.
 .HP
 \fB\-\-min\-small\-malloc\fR <size>
 .IP
-Determine the sizes for the explicite initial large resp. small chunk
-allocation. A size of 0 disables the explicite initial allocations.
+Determine the sizes for the explicit initial large resp. small chunk
+allocation. A size of 0 disables the explicit initial allocations.
 .HP
 \fB\-r\fR u<size> | \fB\-\-reserve\-user\fR <size>
 .HP

--- a/doc/master/runtime_error
+++ b/doc/master/runtime_error
@@ -14,7 +14,7 @@ DESCRIPTION
         the time of the error. <line> is the linenumber within the program.
 
         If the error is a normal runtime error, <culprit> is -1. Otherwise,
-        the error occured during a heartbeat and <culprit> is the object which
+        the error occurred during a heartbeat and <culprit> is the object which
         heart_beat() function was executed. Also, in case of a heartbeat error,
         the heartbeat for the <culprit> has been turned off.
 

--- a/doc/master/runtime_warning
+++ b/doc/master/runtime_warning
@@ -11,7 +11,7 @@ DESCRIPTION
               (the object itself might already be destructed), or 0 if there
               is none.
         <prog>, <line> determine the name of the program and the line where
-              the error occured if the current object exists, otherwise
+              the error occurred if the current object exists, otherwise
               they are 0.
         <inside_catch> : != 0 if the warning occurs inside a catch().
 

--- a/doc/obsolete/debug_info
+++ b/doc/obsolete/debug_info
@@ -47,7 +47,7 @@ DESCRIPTION
             check that it can write the files. The file in question is
             always written anew.
 
-            Result is 1 on success, or 0 if an error occured.
+            Result is 1 on success, or 0 if an error occurred.
 
             <arg2> == "objects": dump information about all live objects.
               Default filename is '/OBJ_DUMP', the valid_write() will read

--- a/etc/savefile-parse.pl
+++ b/etc/savefile-parse.pl
@@ -33,7 +33,7 @@ $parse_err = undef; # Global error messages
 # returns value in perl
 # set start index to next char (if any) or -1
 #
-# If an error occured -1 will be returned and $parse_err set
+# If an error occurred -1 will be returned and $parse_err set
 
 sub get_value {
   my ($offsp, $str, $ret, $ret2, $data);

--- a/mud/lp-245/obj/master.c
+++ b/mud/lp-245/obj/master.c
@@ -890,7 +890,7 @@ handle_super_compat (object super, object ob)
 
 /* For compat muds: handle the weight handling in the environment for
  * prepare_destruct().
- * Return non-0 if an error occured, and 0 if not.
+ * Return non-0 if an error occurred, and 0 if not.
  */
 
 {
@@ -1155,7 +1155,7 @@ mixed heart_beat_error (object culprit, string err,
 //   err    : The error message.
 //   prg    : The executed program (might be 0).
 //   curobj : The object causing the error (might be 0).
-//   line   : The line number where the error occured (might be 0).
+//   line   : The line number where the error occurred (might be 0).
 //
 // Result:
 //   Return anything != 0 to restart the heart_beat in culprit.
@@ -1190,12 +1190,12 @@ void runtime_error ( string err, string prg, string curobj, int line
 //   err    : The error message.
 //   prg    : The executed program.
 //   curobj : The object causing the error.
-//   line   : The line number where the error occured.
+//   line   : The line number where the error occurred.
 //   culprit: -1 for runtime errors; the object holding the heart_beat()
 //            function for heartbeat errors.
 //
 // This function has to announce a runtime error to the active user,
-// resp. handle a runtime error which occured during the execution of
+// resp. handle a runtime error which occurred during the execution of
 // heart_beat() of <culprit>.
 //
 // For a normal runtime error, if the active user is a wizard, it might

--- a/mudlib/master_skeleton.c
+++ b/mudlib/master_skeleton.c
@@ -745,7 +745,7 @@ mixed heart_beat_error (object culprit, string err,
 //   err    : The error message.
 //   prg    : The executed program (might be 0).
 //   curobj : The object causing the error (might be 0).
-//   line   : The line number where the error occured (might be 0).
+//   line   : The line number where the error occurred (might be 0).
 //   caught : 0 if the error is not caught, != 0 if it is caught.
 //
 // Result:
@@ -772,13 +772,13 @@ void runtime_error (string err, string prg, string curobj, int line
 //   err    : The error message.
 //   prg    : The executed program.
 //   curobj : The object causing the error.
-//   line   : The line number where the error occured.
+//   line   : The line number where the error occurred.
 //   culprit: -1 for runtime errors; the object holding the heart_beat()
 //            function for heartbeat errors.
 //   caught : 0 if the error is not caught, != 0 if it is caught.
 //
 // This function has to announce a runtime error to the active user,
-// resp. handle a runtime error which occured during the execution of
+// resp. handle a runtime error which occurred during the execution of
 // heart_beat() of <culprit>.
 //
 // For a normal runtime error, if the active user is a wizard, it might
@@ -827,7 +827,7 @@ void runtime_warning (string msg, string curobj, string prg, int line
 //   err    : The warning message.
 //   curobj : The object causing the warning, may be 0.
 //   prg    : The executed program, may be 0.
-//   line   : The line number where the warning occured.
+//   line   : The line number where the warning occurred.
 //   inside_catch : != 0 if the warning occurs inside a catch().
 //
 // This function is to allow the mudlib to handle runtime warnings, for

--- a/src/actions.c
+++ b/src/actions.c
@@ -1173,7 +1173,7 @@ e_add_action (svalue_t *func, svalue_t *cmd, p_int flag)
 
 /* Implementation of the efun add_action().
  *
- * This function returns TRUE if an error occured, or FALSE if the
+ * This function returns TRUE if an error occurred, or FALSE if the
  * action was successfull.
  */
 

--- a/src/array.c
+++ b/src/array.c
@@ -548,7 +548,7 @@ explode_string (string_t *str, string_t *del)
         /* NOTREACHED */
     } /* --- End of special case --- */
 
-    /* Find the number of occurences of the delimiter 'del' by doing
+    /* Find the number of occurrences of the delimiter 'del' by doing
      * a first scan of the string.
      *
      * The number of array items is then one more than the number of

--- a/src/backend.c
+++ b/src/backend.c
@@ -1039,7 +1039,7 @@ process_objects (void)
  *    Since swapping of variables is costly, care is taken that variables
  *    are not swapped out right before the next reset which in that case
  *    would cause a swap in/swap out-yoyo. Instead, such variable swapping
- *    is delayed until after the reset occured.
+ *    is delayed until after the reset occurred.
  *
  *    To disable swapping, set the swapping times (either in config.h or per
  *    commandline option) to a value <= 0.

--- a/src/call_out.c
+++ b/src/call_out.c
@@ -282,7 +282,7 @@ call_out (void)
 
     if (setjmp(error_recovery_info.con.text))
     {
-        /* An error occured: recover and delete the guilty callout */
+        /* An error occurred: recover and delete the guilty callout */
 
         struct call *cop;
         object_t *ob;

--- a/src/closure.c
+++ b/src/closure.c
@@ -3759,7 +3759,7 @@ compile_value (svalue_t *value, enum compile_value_input_flags opt_flags)
                     case_list_entry_t *save_list0;
                     case_list_entry_t *save_list1;
                       /* Save the vitals of the outer switch.
-                       * We don't need an explicite list of case_states
+                       * We don't need an explicit list of case_states
                        * because compile_value() recurses.
                        */
 
@@ -6938,7 +6938,7 @@ store_case_labels( p_int total_length
         p_int cutoff;       /* Cutoff point during lookup table generation */
 
         /* Walk the list and join consecutive cases to ranges. Intermediate
-         * entries are removed from the list, explicite range end entries
+         * entries are removed from the list, explicit range end entries
          * are left in the list.
          */
         for (last_addr = 0xffffff, list1=list0; list1; list1 = list1->next)

--- a/src/comm.c
+++ b/src/comm.c
@@ -1661,9 +1661,9 @@ add_message (const char *fmt, ...)
  * as <fmt> string to this function.
  *
  * Messages which can't be send (e.g. because the command_giver was
- * destructed or disconnected) are printed on stdout, preceeded by ']'.
+ * destructed or disconnected) are printed on stdout, preceded by ']'.
  *
- * If an error other than EINTR occured while sending the data to
+ * If an error other than EINTR occurred while sending the data to
  * the network, the message is discarded and the socket is marked
  * for disconnection.
  *
@@ -4056,7 +4056,7 @@ call_input_to (interactive_t *i, char *str, input_to_t *it)
 
     if (setjmp(error_recovery_info.con.text))
     {
-        /* An error occured: free the remaining data,
+        /* An error occurred: free the remaining data,
          * restore the error stack and return
          */
 

--- a/src/driver.h
+++ b/src/driver.h
@@ -66,7 +66,7 @@
 
 /* When we have allocation tracing, the allocator annotates every
  * allocation with the source filename and line where the allocation
- * occured. To allow the annotation of the allocations of higher structures
+ * occurred. To allow the annotation of the allocations of higher structures
  * like strings with the place where the string as such is allocated (and not
  * the places in the string module), the following macros can be used
  * to declare and pass the necessary information transparently:

--- a/src/ed.c
+++ b/src/ed.c
@@ -3682,14 +3682,14 @@ print_help (char arg)
     case 'd':
         add_message(
 "Command: d   Usage: d  or [range]d\n"
-"Deletes the current line unless preceeded with a range of lines,\n"
+"Deletes the current line unless preceded with a range of lines,\n"
 "then the entire range will be deleted.\n"
                    );
         break;
 
     case 'e':
         add_message(
-"Commmand: e  Usage: e filename\n"
+"Command: e  Usage: e filename\n"
 "Causes the current file to be wiped from memory, and the new file\n"
 "to be loaded in.\n"
                    );
@@ -3697,7 +3697,7 @@ print_help (char arg)
 
     case 'E':
         add_message(
-"Commmand: E  Usage: E filename\n"
+"Command: E  Usage: E filename\n"
 "Causes the current file to be wiped from memory, and the new file\n"
 "to be loaded in.  Different from 'e' in the fact that it will wipe\n"
 "the current file even if there are unsaved modifications.\n"
@@ -3896,7 +3896,7 @@ print_help (char arg)
             add_message("TODO: document the 's' command\n"
 "Command: s   Usage: s/pat/sub/[g]\n"
 "Replace regular expression <pat> by the text <sub>. If 'g' is given, all\n"
-"occurences of <pat> in a line are replaced, else just the first.\n"
+"occurrences of <pat> in a line are replaced, else just the first.\n"
 "<sub> may reference subexpressions of <pat> with '\\0'..'\\9', or to the\n"
 "whole matched pattern with '\\&'. The special characters '\\t', '\\b',\n"
 "'\\r' and '\\n' are recognized, as is '\\0xxx' for arbitrary characters.\n"

--- a/src/efuns.c
+++ b/src/efuns.c
@@ -1289,14 +1289,14 @@ f_regreplace (svalue_t *sp)
  *     string regreplace (string txt, string pattern, closure|string replace
  *                                                  , int flags)
  *
- * Search through <txt> for one/all occurences of <pattern> and replace them
+ * Search through <txt> for one/all occurrences of <pattern> and replace them
  * with the <replace> pattern, returning the result.
  * <replace> can be a string, or a closure returning a string. If it is
  * a closure, it will be called with the matched substring and
  * the position at which it was found as arguments.
  *
  * <flags> is the bit-or of the regexp options, including:
- *   RE_GLOBAL       = 1: when given, all occurences of <pattern> are replace,
+ *   RE_GLOBAL       = 1: when given, all occurrences of <pattern> are replace,
  *                        else just the first
  *
  * The function behaves like the s/<pattern>/<replace>/<flags> command
@@ -3137,7 +3137,7 @@ f_process_string(svalue_t *sp)
  *
  *     string process_string(string str)
  *
- * Searches string str for occurences of a "value by function
+ * Searches string str for occurrences of a "value by function
  * call", which is @@ followed by an implicit function call. See
  * "value_by_function_call" in the principles section.
  *

--- a/src/files.c
+++ b/src/files.c
@@ -1490,7 +1490,7 @@ f_write_file (svalue_t *sp)
  *   int write_file(string file, string str, int flags = 0)
  *
  * Append the string str to the file <file>. Returns 1 for success
- * and 0 if any failure occured.
+ * and 0 if any failure occurred.
  *
  * If <flags> is 1, the file is first removed; thus effectively
  * changing the 'append' into an 'overwrite'.

--- a/src/heartbeat.c
+++ b/src/heartbeat.c
@@ -171,7 +171,7 @@ call_heart_beat (void)
 
     if (setjmp(error_recovery_info.con.text))
     {
-        /* An error occured: recover. The guilt heartbeat has already
+        /* An error occurred: recover. The guilt heartbeat has already
          * been removed by simulate::error().
          */
         mark_end_evaluation();

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -147,7 +147,7 @@
  *    LPC functions ('lfuns') this means that the actual function call will
  *    remove excessive arguments or push '0's for missing arguments. The
  *    number of arguments will be stored in the control stack, so that
- *    the return instruction not needs to know it explicitely.
+ *    the return instruction not needs to know it explicitly.
  *
  *    If the function called is an lfun (inherited or not), the number
  *    of arguments passed to the call is encoded in the bytecode stream,
@@ -6350,7 +6350,7 @@ svalue_t *
 pull_error_context (svalue_t *sp, svalue_t *msg)
 
 /* Restore the context saved by a catch() after a throw() or runtime error
- * occured. <sp> is the current stackpointer and is used to pop the elements
+ * occurred. <sp> is the current stackpointer and is used to pop the elements
  * pushed since the catch().
  *
  * The function pops the topmost recovery entry, which must be the catch
@@ -6371,7 +6371,7 @@ pull_error_context (svalue_t *sp, svalue_t *msg)
 
     /* If there was a call_other() or similar, previous_ob and current_object
      * must be restored. For this, find the control frame where the call
-     * occured and get the proper values from there.
+     * occurred and get the proper values from there.
      */
     csp2 = p->save_csp;
     while (++csp2 <= csp)
@@ -6523,7 +6523,7 @@ adjust_variable_offsets ( const inherit_t * inheritp
  *
  * TODO: A better compiler might do some backpatching and at least
  * TODO:: leave hints where the variables are, so that we can omit
- * TODO:: the explicite search. Or some load-time patching.
+ * TODO:: the explicit search. Or some load-time patching.
  */
 {
     inherit_t * inh = NULL;
@@ -7201,7 +7201,7 @@ eval_instruction (bytecode_p first_instruction
  * is called recursively.
  *
  * There must not be destructed objects on the stack. The destruct_object()
- * function will automatically remove all occurences. The effect is that
+ * function will automatically remove all occurrences. The effect is that
  * all called efuns know that they won't have destructed objects as
  * arguments.
  *
@@ -9231,7 +9231,7 @@ again:
                 pc += offset;
                 break;
             }
-            /* No need to explicitely free_svalue(), it's just a number */
+            /* No need to explicitly free_svalue(), it's just a number */
         }
         else
         {
@@ -14631,7 +14631,7 @@ again:
          * generates a F_END_CATCH as last instruction of the
          * guarded code.
          *
-         * Executed when no error occured, it returns into
+         * Executed when no error occurred, it returns into
          * catch_instruction() to clean up the
          * error recovery information pushed by the F_CATCH
          * and leave a 0 on the stack.

--- a/src/lex.c
+++ b/src/lex.c
@@ -1486,7 +1486,7 @@ symbol_efun_str (const char * str, size_t len, svalue_t *sp, efun_override_t is_
         }
 
         /* Lookup the identifier in the string in the global table
-         * of identifers.
+         * of identifiers.
          */
         if ( !(p = make_shared_identifier_n(str, len, I_TYPE_GLOBAL, 0)) )
         {
@@ -1895,7 +1895,7 @@ make_global_identifier (char *s, int n)
     ip = make_shared_identifier(s, n, 0);
     if (!ip)
     {
-        yyerrorf("Out of memory: identifer '%s'", s);
+        yyerrorf("Out of memory: identifier '%s'", s);
         return NULL;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1315,7 +1315,7 @@ static Option aOptions[]
     , { 'e', "no-preload",         cNoPreload,      MY_FALSE
       , "  -e|--no-preload\n"
       , "  -e|--no-preload\n"
-        "    Pass a non-zero argument (the number of occurences of this option)\n"
+        "    Pass a non-zero argument (the number of occurrences of this option)\n"
         "    to master->preload(), which usually inhibits all preloads of castles\n"
         "    and other objects.\n"
       }
@@ -1498,8 +1498,8 @@ static Option aOptions[]
       , "  --min-malloc <size>\n"
       , "  --min-malloc <size>\n"
         "  --min-small-malloc <size>\n"
-        "    Determine the sizes for the explicite initial large resp. small chunk\n"
-        "    allocation. A size of 0 disables the explicite initial allocations.\n"
+        "    Determine the sizes for the explicit initial large resp. small chunk\n"
+        "    allocation. A size of 0 disables the explicit initial allocations.\n"
       }
 
     , { 0,   "min-small-malloc",   cMinSmallMalloc, MY_TRUE

--- a/src/object.c
+++ b/src/object.c
@@ -5407,7 +5407,7 @@ static mp_int bytes_written;
    */
 
 static Bool failed;
-  /* An IO error occured.
+  /* An IO error occurred.
    */
 
 static int save_object_descriptor = -1;

--- a/src/pkg-gnutls.c
+++ b/src/pkg-gnutls.c
@@ -951,7 +951,7 @@ tls_read (interactive_t *ip, char *buffer, int length)
 /* Read up to <length> bytes data for the TLS connection of <ip>
  * and store it in <buffer>.
  * Return then number of bytes read, or a negative number if an error
- * occured.
+ * occurred.
  */
 
 {
@@ -1002,7 +1002,7 @@ tls_write (interactive_t *ip, char *buffer, int length)
 
 /* Write <length> bytes from <buffer> to the TLS connection of <ip>
  * Return the number of bytes written, or a negative number if an error
- * occured.
+ * occurred.
  */
 
 {

--- a/src/pkg-mysql.c
+++ b/src/pkg-mysql.c
@@ -316,7 +316,7 @@ raise_db_error (db_dat_t *dat)
 
     if ( !dat || !(tmp = mysql_error(dat->mysql_dat))[0] )
     {
-        errorf( "An unknown error occured during the current database-"
+        errorf( "An unknown error occurred during the current database-"
                "operation\n");
         /* NOTREACHED */
        abort();
@@ -543,7 +543,7 @@ f_db_error (svalue_t *sp)
  *
  *   string db_error(int handle)
  *
- * Return a string describing the error which occured during the last
+ * Return a string describing the error which occurred during the last
  * database transaction. If the last transaction was successful, 0
  * is returned.
  */
@@ -617,7 +617,7 @@ f_db_exec (svalue_t *sp)
 
     if ( mysql_query(dat->mysql_dat, get_txt(s)) )
     {
-        /* either a REAL error occured or just an error in the SQL-statement
+        /* either a REAL error occurred or just an error in the SQL-statement
          */
 
         err_no = mysql_errno(dat->mysql_dat);
@@ -626,7 +626,7 @@ f_db_exec (svalue_t *sp)
             || (err_no == CR_SERVER_LOST)
             || (err_no == CR_UNKNOWN_ERROR) )
         {
-            /* A REAL error occured */
+            /* A REAL error occurred */
             raise_db_error(dat);
             return sp;
         }

--- a/src/pkg-odbc.c
+++ b/src/pkg-odbc.c
@@ -1088,7 +1088,7 @@ raise_critical_sql_exception( hDBC * handle, char * msg )
    if ( handle )
       dispose_db_connection( handle );
    
-   errorf( ( msg ? msg : "An unknown error occured during the current DB operation.\n" ) );
+   errorf( ( msg ? msg : "An unknown error occurred during the current DB operation.\n" ) );
       
    abort();
 }

--- a/src/pkg-openssl.c
+++ b/src/pkg-openssl.c
@@ -1000,7 +1000,7 @@ tls_read (interactive_t *ip, char *buffer, int length)
 /* Read up to <length> bytes data for the TLS connection of <ip>
  * and store it in <buffer>.
  * Return then number of bytes read, or a negative number if an error
- * occured.
+ * occurred.
  */
 
 {
@@ -1056,7 +1056,7 @@ tls_write (interactive_t *ip, char *buffer, int length)
 
 /* Write <length> bytes from <buffer> to the TLS connection of <ip>
  * Return the number of bytes written, or a negative number if an error
- * occured.
+ * occurred.
  */
 
 {

--- a/src/prolang.y
+++ b/src/prolang.y
@@ -1020,7 +1020,7 @@ yyerror (const char *str)
 
 /* Raise the parse error <str>: usually generate the error message and log it.
  * If this is the first error in this file, account the wizard with an error.
- * If too many errors occured already, do nothing.
+ * If too many errors occurred already, do nothing.
  */
 
 {
@@ -5278,7 +5278,7 @@ add_struct_member ( string_t *name, lpctype_t *type
 
     if (STRUCT_MEMBER_COUNT != 0)
     {
-        /* Not the first member: check if the name already occured */
+        /* Not the first member: check if the name already occurred */
         int i;
 
         for ( i = STRUCT_MEMBER_COUNT-1 ; i >= 0 ; i--)
@@ -5379,7 +5379,7 @@ create_struct_literal ( struct_def_t * pdef, int length, struct_init_t * list)
  * Analyze the <list> of member descriptions and generate the appropriate
  * bytecode.
  *
- * Return TRUE on success, and FALSE if an error occured (the caller will
+ * Return TRUE on success, and FALSE if an error occurred (the caller will
  * then clean up the bytecode).
  */
 
@@ -6389,7 +6389,7 @@ printf("DEBUG:     -> F_LOCAL %d\n", lcmap[i]);
                 }
                 else if (got_mapped)
                 {
-                    /* This shouldn't happen, as all explicite context
+                    /* This shouldn't happen, as all explicit context
                      * variables are created before the first implicite
                      * reference can be encountered.
                      */
@@ -9898,7 +9898,7 @@ expr0:
               free_fulltype(restype);
               restype = ref_fulltype(type1);
               if ($2 != F_ASSIGN)
-                  yyerror("Only plain assigment allowed for structs");
+                  yyerror("Only plain assignment allowed for structs");
           }
 
           if ($2 == F_LAND_EQ || $2 == F_LOR_EQ)

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -706,7 +706,7 @@ hs_regcomp (unsigned char *expr, Bool excompat
  * is TRUE; \( \) operators like in Unix ex are allowed. Result is the
  * regexp structure with the program.
  *
- * If an error occured during the compilation, *<errmsg> is set to the
+ * If an error occurred during the compilation, *<errmsg> is set to the
  * static string with the error message, *<erridx> to the approximate
  * position in <expr> where the error happened, and the function returns NULL.
  *

--- a/src/simulate.c
+++ b/src/simulate.c
@@ -259,7 +259,7 @@ string_t *current_error;
 string_t *current_error_file;
 string_t *current_error_object_name;
 mp_int    current_error_line_number;
-  /* When an error occured during secure_apply(), these four
+  /* When an error occurred during secure_apply(), these four
    * variables receive allocated copies (resp. counted refs) of
    * the error message, the name of the active program and object, and the
    * line number in the program.
@@ -269,7 +269,7 @@ vector_t *uncaught_error_trace = NULL;
 vector_t *current_error_trace = NULL;
 string_t *uncaught_error_trace_string = NULL;
 string_t *current_error_trace_string = NULL;
-  /* When an error occured, these variables hold the call chain in the
+  /* When an error occurred, these variables hold the call chain in the
    * format used by efun driver_info() for evaluation by the mudlib.
    * The variables are kept until the next error, or until a GC.
    * 'uncaught_error_trace': the most recent uncaught error
@@ -398,7 +398,7 @@ catch_instruction ( int flags, uint offset
      */
     if ( setjmp( push_error_context(INTER_SP, flags)->text ) )
     {
-        /* A throw() or error occured. We have to restore the
+        /* A throw() or error occurred. We have to restore the
          * control and error stack manually here.
          *
          * The error value to return will be stored in
@@ -620,7 +620,7 @@ dump_core(void)
 void
 fatal (const char *fmt, ...)
 
-/* A fatal error occured. Generate a message from printf-style <fmt>, including
+/* A fatal error occurred. Generate a message from printf-style <fmt>, including
  * a timestamp, dump the backtrace and abort.
  */
 
@@ -725,7 +725,7 @@ limit_error_format (char *fixed_fmt, size_t fixed_fmt_len, const char *fmt)
 void
 errorf (const char *fmt, ...)
 
-/* A system runtime error occured: generate a message from printf-style
+/* A system runtime error occurred: generate a message from printf-style
  * <fmt> with a timestamp, and handle it.
  * If the error is caught, just dump the trace on stderr, and jump to the
  * error handler, otherwise call the mudlib's error functions (this may cause
@@ -1078,7 +1078,7 @@ errorf (const char *fmt, ...)
 
     if (object_name)
     {
-        /* Error occured in a heart_beat() function */
+        /* Error occurred in a heart_beat() function */
 
         object_t *ob;
 
@@ -1250,7 +1250,7 @@ errorf (const char *fmt, ...)
 void
 warnf (char *fmt, ...)
 
-/* A system runtime warning occured: generate a message from printf-style
+/* A system runtime warning occurred: generate a message from printf-style
  * <fmt> with a timestamp, and print it using debug_message(). The message
  * is also passed to master::runtime_warning().
  *

--- a/src/slaballoc.c
+++ b/src/slaballoc.c
@@ -3773,7 +3773,7 @@ esbrk (word_t size, size_t * pExtra)
 
             if (next - p == overhead)
             {
-                /* Our block directly preceedes the next one */
+                /* Our block directly precedes the next one */
                 *(next+1) &= ~PREV_BLOCK;
                 overlap += overhead * GRANULARITY;
                 count_back(&large_wasted_stat, overhead * GRANULARITY);
@@ -4337,7 +4337,7 @@ mem_identify_slab (int fd, const char * tag, int tableIx
                   , mslab_t * list, mslab_t * slab)
 
 /* Check if <slab> is member of the list starting at <listStart>.
- * If yes, print it's information preceeded by <tag> and return TRUE.
+ * If yes, print it's information preceded by <tag> and return TRUE.
  * Return FALSE otherwise.
  */
 

--- a/src/util/xerq/defs.h
+++ b/src/util/xerq/defs.h
@@ -108,7 +108,7 @@ struct equeue_s
 };
 
 /* --- struct socket_s: one socket descriptor
- * This structure is used for explicite TCP/UDP communication, as well
+ * This structure is used for explicit TCP/UDP communication, as well
  * as for the communication with spawned subprograms (then .handle and
  * .ticket are copied from the controlling child_t).
  */

--- a/src/util/xerq/lpc/socketd.c
+++ b/src/util/xerq/lpc/socketd.c
@@ -49,7 +49,7 @@
  * all buffered data is sent. Bear in mind that a Close() will not destruct
  * the socket object in that case and you will get the callbacks if the
  * issuing object still exists. If it does not exist anymore you cannot
- * tell if the data is really sent or some timeout occured. So in general
+ * tell if the data is really sent or some timeout occurred. So in general
  * you should wait with Send()s until the connection is established.
  *
  */
@@ -595,7 +595,7 @@ static void socket_cb(int* msg, int ufd) {
       break;
   }
 
-  // if we get here an error occured. the erq closed the socket already
+  // if we get here an error occurred. the erq closed the socket already
   if (member(sockets, fd)) sockets[fd, S_STATE] = S_CLOSING;
   callback(ufd, SOCKET_CLOSE, 0);
   socket_close(ufd);
@@ -669,7 +669,7 @@ static void write_cb(int* msg, int ufd, int offset) {
       break;
   }
 
-  // if we get here an error occured. the erq closed the socket already
+  // if we get here an error occurred. the erq closed the socket already
   if (member(sockets, fd)) sockets[fd, S_STATE] = S_CLOSING;
   callback(ufd, SOCKET_CLOSE, 0);
   socket_close(ufd);
@@ -939,7 +939,7 @@ static string to_ascii(int* msg) {
   return to_string(msg);
 }
 
-// some erq-error occured, log it
+// some erq-error occurred, log it
 static mixed* note_err(string str, int* msg, int fd) {
   string who, extra, e2;
 

--- a/src/util/xerq/lpc/socketd.man
+++ b/src/util/xerq/lpc/socketd.man
@@ -212,7 +212,7 @@ DESCRIPTION
           SOCKET_CLOSE:      This is called when the connection is closed
                              either from you or the other side.
 
-          SOCKET_ERROR:      An error occured.
+          SOCKET_ERROR:      An error occurred.
                              extra1: Short error message (of the xerq)(string)
                              extra2: The xerq packet with the error or zero
                              extra3: Description of the error ERQ_E_UNKNOWN.

--- a/src/util/xerq/lpc/telnet_ob.c
+++ b/src/util/xerq/lpc/telnet_ob.c
@@ -185,7 +185,7 @@ void input(string str)
 	}
 	case '?': {
 	  write("telnet: Escape commands:\n"
-		"All commands are preceeded by the escape (^[) character.\n"
+		"All commands are preceded by the escape (^[) character.\n"
 		"\n"
 		"c          Close session log.\n"
 		"d          Detach telnet session.\n"

--- a/src/util/xerq/socket.c
+++ b/src/util/xerq/socket.c
@@ -108,7 +108,7 @@ int
 flush_queue (equeue_t **qpp, int fd, int reply_handle)
 
 /* Try to write all pending data from queue <qpp> to socket <fd>.
- * Return -1 if an error occured, and 0 if the queue could be emptied.
+ * Return -1 if an error occurred, and 0 if the queue could be emptied.
  * Single queue elements which have been written are always removed.
  */
 
@@ -246,7 +246,7 @@ read_socket (socket_t *sp, int rw)
  *
  * If there is data pending on the socket, try to write it in any case.
  *
- * Return 0 on success, 1 if an error occured and the socket has been closed.
+ * Return 0 on success, 1 if an error occurred and the socket has been closed.
  */
 
 {
@@ -798,7 +798,7 @@ static int
 send_auth (auth_t *ap)
 
 /* We got connection to the authd - send our request.
- * Return 0 on success, 1 if an error occured and the socket has been closed.
+ * Return 0 on success, 1 if an error occurred and the socket has been closed.
  */
 
 {

--- a/src/wiz_list.c
+++ b/src/wiz_list.c
@@ -410,7 +410,7 @@ remove_wiz_list (void)
 void
 save_error (const char *msg, const char *file, int line)
 
-/* A runtime error <msg> occured for object <file> in line number <line>.
+/* A runtime error <msg> occurred for object <file> in line number <line>.
  * Store this information in the wizlist so that the mudlib can handle
  * it later with the efun get_error_file().
  * TODO: A proper runtime error handling could put this into the mudlib
@@ -643,11 +643,11 @@ f_get_error_file (svalue_t *sp)
  *
  *   mixed * get_error_file(string name, int set_forget_flag)
  *
- * Return information about the last error which occured for
+ * Return information about the last error which occurred for
  * <name> (where <name> is a valid name from the wiz list).
  *
  * Result is an array of four elements: the filename of the
- * program where the error occured, the linenumber in the
+ * program where the error occurred, the linenumber in the
  * program, the error message (runtime error messages usually
  * start with a '*'), and a numerical flag (the 'forget flag') if
  * the error information has been queried already.


### PR DESCRIPTION
I am trying to package ldmud for debian and their lintian tool when doing pedantic checking is complaining about spelling errors. Some of them were false positives, but these ones weren't