### PR TITLE
Fixing spelling errors in docs and output strings

### DIFF
--- a/doc/LPC/foreach
+++ b/doc/LPC/foreach
@@ -80,7 +80,7 @@ DESCRIPTION
              a = ({1, 2, 3})
              foreach(x : a) { a[1..2] = ({4, 5}); write(x+" "); }
            will write ("1 4 5 ").
-         - operations which implicitely copy the array or struct (this
+         - operations which implicitly copy the array or struct (this
            includes range assignments which change the size) don't
            have an effect on the loop.
 

--- a/doc/LPC/inline-closures
+++ b/doc/LPC/inline-closures
@@ -43,7 +43,7 @@ DESCRIPTION
         But changes of the closure context will not reflect on the
         local variable it was copied from and vice versa.
 
-        In addition to the implicite context inherited from the
+        In addition to the implicit context inherited from the
         defining function, additional context variables can be defined
         in the closure:
 

--- a/doc/concepts/hooks
+++ b/doc/concepts/hooks
@@ -31,7 +31,7 @@ DESCRIPTION
         H_CREATE_CLONE
           Optional hooks to initialize an object after creation.
 
-          H_CREATE_SUPER is called for blueprints implicitely loaded
+          H_CREATE_SUPER is called for blueprints implicitly loaded
           by inheritance, H_CREATE_OB for explicitely loaded
           blueprints/objects, and H_CREATE_CLONE for cloned objects.
 

--- a/doc/efun/clone_object
+++ b/doc/efun/clone_object
@@ -33,7 +33,7 @@ DESCRIPTION
         with a call to the internal lfun __INIT().
         
         However, if #pragma share_variables is in effect (either explicitely
-        given in the source or implicitely as runtime option), the values for
+        given in the source or implicitly as runtime option), the values for
         a clone's uninitialized variables are taken from the _current_
         variables of the object's blueprint.
 

--- a/mud/lp-245/obj/team.c
+++ b/mud/lp-245/obj/team.c
@@ -80,7 +80,7 @@ int join(string str) {
 	ob->query_name() + " to his team.\n", ob);
     tell_object(ob, "You are joined to the team of " +
 		leader_name + ".\n");
-    members = add(ob); /* takes members implicitely */
+    members = add(ob); /* takes members implicitly */
     write("Ok.\n");
     enable_commands();
     return 1;

--- a/src/object.c
+++ b/src/object.c
@@ -92,7 +92,7 @@
  *
  * .variables is the block of variables of this object. Obviously they
  * can't be shared between master and clones. The number of variables
- * implicitely known by the program.
+ * implicitly known by the program.
  *
  * .name and .load_name are the two names of the object. .name (an untabled
  * string) is the objects 'real' name: something like "std/thing" for

--- a/src/prolang.y
+++ b/src/prolang.y
@@ -6390,11 +6390,11 @@ printf("DEBUG:     -> F_LOCAL %d\n", lcmap[i]);
                 else if (got_mapped)
                 {
                     /* This shouldn't happen, as all explicit context
-                     * variables are created before the first implicite
+                     * variables are created before the first implicit
                      * reference can be encountered.
                      */
-                    fatal("Explicite context var #%d has higher index than "
-                          "implicite context variables.", i);
+                    fatal("Explicit context var #%d has higher index than "
+                          "implicit context variables.", i);
                 }
                 else
                     num_explicit_context++;

--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -1685,7 +1685,7 @@ static char buff[BUFF_SIZE];         /* For error messages */
             }
 
             column_stat = 0; /* If there was a newline pending, it
-                              * will be implicitely added now.
+                              * will be implicitly added now.
                               */
             ADD_CHAR(st, '\n');
             st->line_start = st->bpos;

--- a/src/util/erq/erq.c
+++ b/src/util/erq/erq.c
@@ -1518,7 +1518,7 @@ main (int argc, char **argv)
         }
         else
         {
-            fprintf(stderr, "%s dynamic attachement unimplemented\n", time_stamp());
+            fprintf(stderr, "%s dynamic attachment unimplemented\n", time_stamp());
             goto die;
         }
     }

--- a/src/util/xerq/erq.c
+++ b/src/util/xerq/erq.c
@@ -192,7 +192,7 @@ main(int argc, char *argv[])
         }
         else
         {
-            fprintf(stderr, "%s Dynamic attachement unimplemented\n"
+            fprintf(stderr, "%s Dynamic attachment unimplemented\n"
                           , time_stamp());
             die();
         }


### PR DESCRIPTION
It seems I didn't catch all the mispellings in my last pull request.
explicit was mispelled as explicite in a few places
implicit was mispelled as implicite in a few places
attachment was mispelled attachement in a few places