### PR TITLE
Added more signal handling actions.

### DIFF
--- a/doc/efun/configure_driver
+++ b/doc/efun/configure_driver
@@ -142,6 +142,43 @@ DESCRIPTION
            <data> is an integer and measured in seconds.
            (Same as the --reset-time command line switch.)
 
+        <what> == DC_DEBUG_FILE
+           Sets the debug log file.
+           The filename can be given relative to the mudlib directory
+           or absolute with regard to the operating system.
+           Settings this option will force closing and reopening
+           the log file (even if the name didn't change).
+
+         <what> == DC_SIGACTION_SIGHUP
+         <what> == DC_SIGACTION_SIGINT
+         <what> == DC_SIGACTION_SIGUSR1
+         <what> == DC_SIGACTION_SIGUSR2
+           Sets the default action when the driver encounters those
+           POSIX signals. It can be set to one of the following options:
+
+             DCS_DEFAULT:
+                 This is the default action: Call handle_external_signal()
+                 in the master and act upon its result.
+
+             DCS_IGNORE:
+                 Ignore the signal.
+
+             DCS_TERMINATE:
+                 Terminate the process immediately.
+
+             DCS_SHUTDOWN:
+                 Do a graceful shutdown.
+
+             DCS_INFORM_MASTER:
+                 Call handle_external_signal(), but ignore its result.
+
+             DCS_RELOAD_MASTER:
+                 Reload the master object.
+
+             DCS_THROW_EXCEPTION:
+                 Cause an error in the currently running LPC or Python
+                 function.
+
 HISTORY
         Introduced in LDMud 3.3.719.
         DC_ENABLE_HEART_BEATS was added in 3.5.0.
@@ -156,6 +193,8 @@ HISTORY
         DC_SWAP_VAR_TIME was added in 3.5.2
         DC_CLEANUP_TIME was added in 3.5.2
         DC_RESET_TIME was added in 3.5.2
+        DC_DEBUG_FILE was added in 3.5.2.
+        DC_SIGACTION_* were added in 3.5.2.
 
 SEE ALSO
         configure_interactive(E)

--- a/mudlib/sys/configuration.h
+++ b/mudlib/sys/configuration.h
@@ -41,5 +41,21 @@
 #define DC_SWAP_VAR_TIME                 11
 #define DC_CLEANUP_TIME                  12
 #define DC_RESET_TIME                    13
+#define DC_DEBUG_FILE                    14
+
+#define DC_SIGACTION_SIGHUP              20
+#define DC_SIGACTION_SIGINT              21
+#define DC_SIGACTION_SIGUSR1             22
+#define DC_SIGACTION_SIGUSR2             23
+
+/* Values for the DC_SIGACTION_SIG* options:
+ */
+#define DCS_DEFAULT                      0
+#define DCS_IGNORE                       1
+#define DCS_TERMINATE                    2
+#define DCS_SHUTDOWN                     3
+#define DCS_INFORM_MASTER                4
+#define DCS_RELOAD_MASTER                5
+#define DCS_THROW_EXCEPTION              6
 
 #endif /* LPC_CONFIGURATION_H_ */

--- a/src/backend.c
+++ b/src/backend.c
@@ -75,6 +75,7 @@
 
 #include "i-eval_cost.h"
 
+#include "../mudlib/sys/configuration.h"
 #include "../mudlib/sys/driver_hook.h"
 #include "../mudlib/sys/debug_message.h"
 #include "../mudlib/sys/signals.h"
@@ -135,6 +136,10 @@ Bool extra_jobs_to_do = MY_FALSE;
    *   parsing commands or calling the heart_beat.
    */
 
+volatile bool interrupt_execution = false;
+  /* True: abort the current execution with an error.
+   */
+
 GC_Request gc_request = gcDont;
   /* gcDont: No garbage collection is due.
    * gcMalloc: The mallocator requested a gc (requires extra_jobs_to_do).
@@ -168,6 +173,14 @@ static time_t time_last_slow_shut = 0;
 
 static sigset_t pending_signals;
 /* The pending signals which should be delivered to the mudlib master.
+ */
+
+char sigaction_sighup  = DCS_DEFAULT,
+      sigaction_sigint  = DCS_DEFAULT,
+      sigaction_sigusr1 = DCS_DEFAULT,
+      sigaction_sigusr2 = DCS_DEFAULT;
+/* Configured reactions to signals, is one of DCS_* defines.
+ * They are evaluated immediately when the signal occurs.
  */
 
 /*-------------------------------------------------------------------------*/
@@ -305,34 +318,149 @@ do_state_check (int minlvl, const char *where)
 #endif
 
 /*-------------------------------------------------------------------------*/
+static bool install_sigint_handler();
+
 static void
 handle_signal (int sig)
 
-/* General signal handler: store the signal in a flag
+/* General signal handler:
+ * First we look at the configured actions: IGNORE, TERMINATE and
+ * THROW_EXCEPTION we handle immediately. For all other we store
+ * the signal in a flag to be handled in the backend loop.
+ *
  * Note: If we receive the same signal again before it is processed, the second
  *       signal will be lost.
  */
 {
-    sigaddset(&pending_signals, sig);
-    extra_jobs_to_do = MY_TRUE;
+    char action = DCS_DEFAULT;
+    switch (sig)
+    {
+        case SIGHUP:
+            action = sigaction_sighup;
+            break;
+
+        case SIGINT:
+            action = sigaction_sigint;
+            break;
+
+        case SIGUSR1:
+            action = sigaction_sigusr1;
+            break;
+
+        case SIGUSR2:
+            action = sigaction_sigusr2;
+            break;
+    }
+
+    switch (action)
+    {
+        case DCS_IGNORE:
+            /* Do nothing. */
+            break;
+
+        case DCS_TERMINATE:
+        {
+            /* Call the default handler, for all four signals
+             * this is termination.
+             */
+            struct sigaction sa;
+            sigemptyset(&sa.sa_mask);
+            sa.sa_flags = 0;
+            sa.sa_handler = SIG_DFL;
+            if (sigaction(sig, &sa, NULL) == 0)
+                raise(sig);
+            /* If we are still here, exit... */
+            exit(sig);
+            return;
+        }
+
+        case DCS_THROW_EXCEPTION:
+            /* Set a flag to be evaluated by the interpreter. */
+            interrupt_execution = true;
+#ifdef USE_PYTHON
+            /* Notify the python package. */
+            python_interrupt();
+#endif
+            break;
+
+        default:
+            /* Process it in the backend loop. */
+            sigaddset(&pending_signals, sig);
+            extra_jobs_to_do = MY_TRUE;
+            return;
+    }
+
+    // Reached in case of DCS_IGNORE and DCS_THROW_EXCEPTION.
+    // In both cases the signal handler has to be re-installed here
+    // (because process_pending_signals() - which would do it normally -
+    // isn't going to be called in these cases).
+    if (sig == SIGINT)
+        install_sigint_handler();
+
 } /* handle_signal() */
 
 /*-------------------------------------------------------------------------*/
-static INLINE Bool
-defer_signal_to_master(int sig)
-// Notifies master about the signal <sig>.
-// Returns 1 if the master returns anything != 0. In this case it is assumed,
-// the master handled the signal.
+static bool
+install_sigint_handler ()
+
+/* Installs the SIGINT handler again.
+ * The handler is reset upon each signal, so we need to install it again.
+ * Returns true on success.
+ */
+
 {
-    svalue_t *res;
-    push_number(inter_sp, sig);
-    res = callback_master(STR_HANDLE_EXTERNAL_SIGNAL, 1);
-    if (res && res->type == T_NUMBER && res->u.number != 0)
+    struct sigaction sa;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART|SA_RESETHAND;
+    sa.sa_handler = handle_signal;
+    return (sigaction(SIGINT, &sa, NULL) == 0);
+}
+
+/*-------------------------------------------------------------------------*/
+static INLINE bool
+execute_signal_action (int sig, char configured)
+
+/* Executes the configured signal action, that were not already handled in the
+ * signal handler itself: DEFAULT, SHUTDOWN, CALL_MASTER and RELOAD_MASTER.
+ *
+ * Returns true, if the action was executed.
+ * Returns false, if the default action (besides calling the master)
+ * shall be conducted.
+ */
+
+{
+    switch (configured)
     {
-        return MY_TRUE;
+        case DCS_SHUTDOWN:
+            extra_jobs_to_do = MY_TRUE;
+            game_is_being_shut_down = MY_TRUE;
+            break;
+
+        case DCS_RELOAD_MASTER:
+            extra_jobs_to_do = MY_TRUE;
+            master_will_be_updated = MY_TRUE;
+            break;
+
+        case DCS_INFORM_MASTER:
+        default:
+        {
+            svalue_t *res;
+
+            push_number(inter_sp, sig);
+            res = callback_master(STR_HANDLE_EXTERNAL_SIGNAL, 1);
+
+            // If we just inform the master or the master returned something
+            // that is not a number or the number 0 we go to the default action.
+            if (configured == DCS_INFORM_MASTER ||
+                !res || res->type != T_NUMBER || res->u.number == 0)
+                return false;
+
+            break;
+        }
     }
-    return MY_FALSE;
-} /* defer_signal_to_master() */
+
+    return true;
+} /* execute_signal_action() */
 
 /*-------------------------------------------------------------------------*/
 static INLINE void
@@ -345,7 +473,8 @@ process_pending_signals (void)
     if (sigismember(&pending_signals, SIGTERM))
     {
         // SIGTERM: shutdown gracefully, but inform the mudlib master first.
-        defer_signal_to_master(LPC_SIGTERM);
+        //          The master can't veto the shutdown.
+        execute_signal_action(LPC_SIGTERM, DCS_DEFAULT);
         game_is_being_shut_down = MY_TRUE;
         // ignore the rest of the signals
         sigemptyset(&pending_signals);
@@ -355,7 +484,7 @@ process_pending_signals (void)
     {
         // SIGHUP: request a game shutdown.
         sigdelset(&pending_signals, SIGHUP);
-        if (!defer_signal_to_master(LPC_SIGHUP))
+        if (!execute_signal_action(LPC_SIGHUP, sigaction_sighup))
         {
             // master did not handle it, shut down.
             extra_jobs_to_do = MY_TRUE;
@@ -369,7 +498,7 @@ process_pending_signals (void)
     {
         // SIGUSR1: request a master update.
         sigdelset(&pending_signals, SIGUSR1);
-        if (!defer_signal_to_master(LPC_SIGUSR1))
+        if (!execute_signal_action(LPC_SIGUSR1, sigaction_sigusr1))
         {
             // Master did not handle it, update the master
             extra_jobs_to_do = MY_TRUE;
@@ -381,7 +510,7 @@ process_pending_signals (void)
     {
         // SIGUSR2: reopen the debug.log file.
         sigdelset(&pending_signals, SIGUSR2);
-        if (!defer_signal_to_master(LPC_SIGUSR2))
+        if (!execute_signal_action(LPC_SIGUSR2, sigaction_sigusr2))
         {
             // Master did not handle it, re-open the log
             reopen_debug_log = MY_TRUE;
@@ -393,7 +522,7 @@ process_pending_signals (void)
         // does not handle the signal, we send us the signal again (which terminates
         // us).
         sigdelset(&pending_signals, SIGINT);
-        if (!defer_signal_to_master(LPC_SIGINT))
+        if (!execute_signal_action(LPC_SIGINT, sigaction_sigint))
         {
             // if anything goes wrong, we terminate ourself, because it is the
             // standard behaviour in case of SIGINT.
@@ -406,15 +535,10 @@ process_pending_signals (void)
         // Otherwise we install our own handler again (the signal handler for
         // SIGINT is installed with the SA_RESETHAND flag and thus reset upon 
         // signal delivery)
-        else
+        else if (!install_sigint_handler())
         {
-            struct sigaction sa;
-            sigemptyset(&sa.sa_mask);
-            sa.sa_flags = SA_RESTART|SA_RESETHAND;
-            sa.sa_handler = handle_signal;
-            if (sigaction(SIGINT, &sa, NULL) == -1)
-                debug_message("%s Unable to reinstall signal handler for SIGINT: %s",
-                      time_stamp(), strerror(errno));
+            debug_message("%s Unable to reinstall signal handler for SIGINT: %s",
+                  time_stamp(), strerror(errno));
         }
     }
 } // process_pending_signals
@@ -506,6 +630,7 @@ void install_signal_handlers()
     // for SIGTERM and SIGINT the default handler should be restored upon signal
     // delivery, so that a repeated signal is handled immediately with the 
     // default action and not only in the next backend cycle.
+    sa.sa_handler = handle_signal;
     sa.sa_flags |= SA_RESETHAND;
     if (sigaction(SIGINT, &sa, NULL) == -1)
         perror("Unable to install signal handler for SIGINT");

--- a/src/backend.c
+++ b/src/backend.c
@@ -421,7 +421,7 @@ static INLINE bool
 execute_signal_action (int sig, char configured)
 
 /* Executes the configured signal action, that were not already handled in the
- * signal handler itself: DEFAULT, SHUTDOWN, CALL_MASTER and RELOAD_MASTER.
+ * signal handler itself: DEFAULT, SHUTDOWN, INFORM_MASTER and RELOAD_MASTER.
  *
  * Returns true, if the action was executed.
  * Returns false, if the default action (besides calling the master)

--- a/src/backend.h
+++ b/src/backend.h
@@ -35,6 +35,7 @@ extern statistic_t stat_last_data_cleaned;
 extern statistic_t stat_in_list;
 
 extern Bool extra_jobs_to_do;
+extern volatile bool interrupt_execution;
 
 typedef enum { gcDont = 0, gcMalloc, gcEfun } GC_Request;
 extern GC_Request gc_request;
@@ -42,6 +43,8 @@ extern statistic_t stat_load;
 extern statistic_t stat_compile;
 
 extern Bool mud_is_up;
+
+extern char sigaction_sighup, sigaction_sigint, sigaction_sigusr1, sigaction_sigusr2;
 
 /* --- Prototypes --- */
 

--- a/src/efuns.c
+++ b/src/efuns.c
@@ -8553,6 +8553,48 @@ f_configure_driver (svalue_t *sp)
             time_to_reset = sp->u.number;
             break;
 
+        case DC_DEBUG_FILE:
+            if (sp->type != T_STRING)
+                efun_arg_error(2, T_STRING, sp->type, sp);
+            else
+            {
+                free(debug_file);
+                debug_file = strdup(get_txt(sp->u.str));
+
+                reopen_debug_log = true;
+            }
+            break;
+
+        case DC_SIGACTION_SIGHUP:
+        case DC_SIGACTION_SIGINT:
+        case DC_SIGACTION_SIGUSR1:
+        case DC_SIGACTION_SIGUSR2:
+            if (sp->type != T_NUMBER)
+                efun_arg_error(2, T_NUMBER, sp->type, sp);
+            else if (sp->u.number < 0 || sp->u.number > DCS_THROW_EXCEPTION)
+                errorf("Illegal value for signal action in configure_driver()\n");
+            else
+            {
+                switch(sp[-1].u.number)
+                {
+                    case DC_SIGACTION_SIGHUP:
+                        sigaction_sighup = (char) sp->u.number;
+                        break;
+
+                    case DC_SIGACTION_SIGINT:
+                        sigaction_sigint = (char) sp->u.number;
+                        break;
+
+                    case DC_SIGACTION_SIGUSR1:
+                        sigaction_sigusr1 = (char) sp->u.number;
+                        break;
+
+                    case DC_SIGACTION_SIGUSR2:
+                        sigaction_sigusr2 = (char) sp->u.number;
+                        break;
+                }
+            }
+            break;
     }
 
     // free arguments
@@ -8656,6 +8698,26 @@ f_driver_info (svalue_t *sp)
 
         case DC_SWAP_COMPACT_MODE:
             put_number(&result, swap_compact_mode);
+            break;
+
+        case DC_DEBUG_FILE:
+            put_string(&result, new_mstring(debug_file));
+            break;
+
+        case DC_SIGACTION_SIGHUP:
+            put_number(&result, sigaction_sighup);
+            break;
+
+        case DC_SIGACTION_SIGINT:
+            put_number(&result, sigaction_sigint);
+            break;
+
+        case DC_SIGACTION_SIGUSR1:
+            put_number(&result, sigaction_sigusr1);
+            break;
+
+        case DC_SIGACTION_SIGUSR2:
+            put_number(&result, sigaction_sigusr2);
             break;
 
         /* Driver Environment */

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -835,6 +835,10 @@ mark_start_evaluation (void)
     }
     
     used_memory_at_eval_start = xalloc_used();
+
+    /* Also reset any interrupt flag that happened between threads. */
+    interrupt_execution = false;
+
 } /* mark_start_evaluation() */
 
 /*-------------------------------------------------------------------------*/
@@ -15655,6 +15659,14 @@ again:
                 "exceeded limit: %"PRIdPINT", allowed: %"PRIdPINT".\n",
                 xalloc_used() - used_memory_at_eval_start,
                 max_memory));
+    }
+
+    // Was there a signal to terminate this thread?
+    if (interrupt_execution)
+    {
+        /* Reset the flag, so the error handler can execute. */
+        interrupt_execution = false;
+        ERRORF(("Interrupt by external signal.\n"));
     }
 
     /* Execute the next instruction */

--- a/src/pkg-python.h
+++ b/src/pkg-python.h
@@ -55,6 +55,8 @@ extern void python_handle_fds(fd_set *readfds, fd_set *writefds, fd_set *exceptf
 extern void python_call_hook(int hook, bool is_external);
 extern void python_call_hook_object(int hook, bool is_external, object_t *ob);
 
+extern void python_interrupt();
+
 #ifdef GC_SUPPORT
 extern void python_clear_refs();
 extern void python_count_refs();


### PR DESCRIPTION
The mudlib can now configure signal handling for
SIGINT, SIGHUP, SIGUSR1 and SIGUSR2 via configure_driver().
Added the new possibility of interrupting an LPC or Python
execution thread via a signal.