### PR TITLE
More featureful lpc mode in indent.

### DIFF
--- a/src/util/indent/args.c
+++ b/src/util/indent/args.c
@@ -29,13 +29,18 @@ static char sccsid[] = "@(#)args.c	5.6 (Berkeley) 9/15/88";
 
 #include "indent_globs.h"
 #include <ctype.h>
+#include <string.h>
 #include "version.h"
+#include "io.h"
+#include "lexi.h"
 
 int else_endif_col;
 
 extern char *in_name;
 
 char       *getenv();
+void       scan_profile(FILE *f);
+void       set_option( char *arg, int explicit);
 
 /* profile types */
 enum profile {PRO_BOOL, /* boolean */
@@ -241,7 +246,7 @@ struct pro pro[] = {
  * set_profile reads $HOME/.indent.pro and ./.indent.pro and handles arguments
  * given in these files.
  */
-set_profile()
+void set_profile()
 {
     register FILE *f;
     char *fname;
@@ -263,7 +268,7 @@ set_profile()
     free (fname);
 }
 
-scan_profile(f)
+void scan_profile(f)
     register FILE *f;
 {
     register int i;
@@ -287,7 +292,7 @@ scan_profile(f)
    an argument.  Compare the two, returning true if they are equal,
    and if they are equal set *START_PARAM to point to the argument
    in S2.  */
-eqin(s1, s2, start_param)
+int eqin(s1, s2, start_param)
      register char *s1;
      register char *s2;
      char **start_param;
@@ -303,7 +308,7 @@ eqin(s1, s2, start_param)
 /*
  * Set the defaults.
  */
-set_defaults()
+void set_defaults()
 {
     register struct pro *p;
 
@@ -317,7 +322,7 @@ set_defaults()
    specified (as opposed to being taken from a PRO_SETTINGS group of
    settings).  */
 
-set_option (arg, explicit)
+void set_option (arg, explicit)
      char *arg;
      int explicit;
 {

--- a/src/util/indent/args.h
+++ b/src/util/indent/args.h
@@ -1,0 +1,3 @@
+void set_defaults();
+void set_profile();
+void set_option(char *arg,int explicit);

--- a/src/util/indent/indent_globs.h
+++ b/src/util/indent/indent_globs.h
@@ -96,7 +96,7 @@ GLOBAL FILE       *output;		/* the output file */
 #endif
 #define check_size(name) \
 	if (paste(e_,name) >= paste(l_,name)) { \
-	    register nsize = paste(l_,name)-paste(s_,name)+400; \
+	    register int nsize = paste(l_,name)-paste(s_,name)+400; \
 	    paste(name,buf) = (char *) xrealloc(paste(name,buf), nsize); \
 	    paste(e_,name) = paste(name,buf) + \
 	      (paste(e_,name)-paste(s_,name)) + 1; \

--- a/src/util/indent/io.h
+++ b/src/util/indent/io.h
@@ -1,0 +1,14 @@
+void read_stdin();
+void parsefont(register struct fstate *f,char *s0);
+int count_spaces(int current, char *buffer);
+int compute_code_target();
+int compute_label_target();
+void dump_line();
+void fill_buffer();
+void diag(int level,const char *msg, ...); 
+int pad_output(int current,int target);
+void read_file(char *filename);
+void writefdef(register struct fstate *f,int nm);
+
+
+

--- a/src/util/indent/lexi.c
+++ b/src/util/indent/lexi.c
@@ -32,6 +32,7 @@ static char sccsid[] = "@(#)lexi.c	5.11 (Berkeley) 9/15/88";
 #include "indent_globs.h"
 #include "ctype.h"
 #include "io.h"
+#include "lexi.h"
 
 #define alphanum 1
 #define opchar 3

--- a/src/util/indent/lexi.h
+++ b/src/util/indent/lexi.h
@@ -1,0 +1,14 @@
+enum rwcodes {
+  rw_break,
+  rw_switch,
+  rw_case,
+  rw_struct_like, /* struct, enum, union */
+  rw_decl,
+  rw_sp_paren, /* if, while, for */
+  rw_sp_nparen, /* do, else */
+  rw_sizeof
+  };
+
+void addkey(char *key,enum rwcodes val);
+enum codes lexi();
+

--- a/src/util/indent/parse.c
+++ b/src/util/indent/parse.c
@@ -23,7 +23,9 @@ static char sccsid[] = "@(#)parse.c	5.8 (Berkeley) 9/15/88";
 #endif /* not lint */
 
 #include "indent_globs.h"
+#include "io.h"
 
+void reduce();
 struct parser_state *parser_state_tos;
 
 /* like ++parser_state_tos->tos but checks for stack overflow and extends
@@ -277,7 +279,7 @@ parse(tk)
 /*----------------------------------------------*\
 |   REDUCTION PHASE				    |
 \*----------------------------------------------*/
-reduce()
+void reduce()
 {
 
     register int i;

--- a/src/util/indent/parse.h
+++ b/src/util/indent/parse.h
@@ -1,0 +1,1 @@
+void parse(enum codes tk);

--- a/src/util/indent/pr_comment.c
+++ b/src/util/indent/pr_comment.c
@@ -55,9 +55,9 @@ static char sccsid[] = "@(#)pr_comment.c	5.9 (Berkeley) 9/15/88";
 
 
 #include "indent_globs.h"
+#include "io.h"
 
-
-pr_comment()
+void pr_comment()
 {
     int         now_col;	/* column we are in now */
     int         adj_max_col;	/* Adjusted max_col for when we decide to
@@ -114,7 +114,7 @@ pr_comment()
 		parser_state_tos->com_col = 1 + !format_col1_comments;
 	}
 	else {
-	    register    target_col;
+	    register int   target_col;
 	    break_delim = 0;
 	    if (s_code != e_code)
 		target_col = count_spaces(compute_code_target(), s_code);

--- a/src/util/indent/pr_comment.h
+++ b/src/util/indent/pr_comment.h
@@ -1,0 +1,2 @@
+void pr_comment();
+


### PR DESCRIPTION
lpc mode now understands closures and symbols.
It will also avoid treating a colon as a label for goto,
outdenting only for case statements in a switch.
Using va_args for error printing.