### PR TITLE
Updates for StickMUD

### DIFF
--- a/src/settings/README
+++ b/src/settings/README
@@ -35,7 +35,8 @@ The provided settings:
   psycmuve:        settings for PSYC
   quovadis:        settings for Quo Vadis
   silberland:      settings for SilberLand
-  sticklib:        settings for StickLib
+  sticklib:        settings for StickLib (dist lib of StickMUD)
+  stickmud:        settings for StickMUD
   theland:         settings for The Land
   timewarp:        settings for TimeWarp
   traumland:       settings for Traumland

--- a/src/settings/stickmud
+++ b/src/settings/stickmud
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# Settings for the StickMUD
+#
+# configure will strip this part from the script.
+
+#export LDFLAGS="-L/usr/local/opt/libiconv/lib -L/usr/local/opt/pcre/lib -L/usr/lib ${LDFLAGS}"
+#export CPPFLAGS="-I/usr/local/opt/libiconv/include -I/usr/local/opt/pcre/include -I/usr/include ${CPPFLAGS}"
+#export CFLAGS="-I/usr/include ${CFLAGS}"
+#export EXTRA_CFLAGS=$CFLAGS
+
+exec ./configure --prefix=/Users/stickmud/live/ldmud --libdir=/Users/stickmud/live/ldmud/lib --bindir=/Users/stickmud/live/ldmud/bin --with-setting=stickmud $*
+exit 1
+
+# --- The actual settings ---
+
+with_portno=7680
+with_udp_port=7690
+with_max_players=200
+with_time_to_swap=0
+with_time_to_swap_variables=0
+with_time_clean_up=3600
+with_time_to_reset=1800
+with_read_file_max_size=100000
+with_max_byte_transfer=100000
+with_otable_size=131072
+with_htable_size=131072
+with_max_array_size=10000
+with_max_mapping_keys=20000
+with_max_mapping_size=60000
+with_max_malloced=0
+with_max_cost=2000000
+with_master_name=secure/master_amy
+with_max_trace=100
+with_max_user_trace=60
+with_evaluator_stack_size=5000
+with_erq_debug=4
+
+enable_erq=xerq
+enable_access_control=no
+enable_dynamic_costs=yes
+enable_compat_mode=yes
+enable_strict_euids=no
+enable_supply_parse_command=no
+enable_initialization_by___init=no
+enable_malloc_trace=no
+enable_malloc_lpc_trace=no
+enable_comm_stat=yes
+enable_apply_cache_stat=yes
+enable_use_parse_command=no
+enable_use_pcre=yes
+enable_use_json=yes
+enable_use_xml=yes
+enable_use_mysql=no
+enable_use_ipv6=no


### PR DESCRIPTION
StickMUD is now on the 3.6.2 release and instead of recopying these files each time we update I have included them here.  Once I get StickLib, the distributable version of StickMUD, updated to the same driver I will return and clean up all the references in LDMud for StickLib.  Good work on the UTF-8 additions.  Thank you!

-Tamarindo@StickMUD