### PR TITLE
[documentation] minor updates

### DIFF
--- a/doc/LPC/types
+++ b/doc/LPC/types
@@ -5,8 +5,8 @@ DESCRIPTION
 
     Variables can have the following types:
 
-    o int       An integer. Normally full 32 bits signed, yielding a
-                range of at least -2,147,483,648 to 2,147,483,647. The
+    o int       An integer. Normally 32 bits or 64 bits signed, yielding
+                a range of at least -2,147,483,648 to 2,147,483,647. The
                 exact available range is given by the predefined
                 macros __INT_MIN__ and __INT_MAX__.
 
@@ -120,9 +120,9 @@ DESCRIPTION
                 create the closure as ({ ..., foo, ... })
 
     o float     A floating point number in the absolute range
-                __FLOAT_MIN__ to __FLOAT_MAX__ (typically 1e-38 to 1e+38).
-                Floating point numbers are signified by a '.'
-                appearing, e.g. '1' is integer 1, but '1.' is
+                __FLOAT_MIN__ to __FLOAT_MAX__ (typically 2.2e-308 to
+                1.8e+308). Floating point numbers are signified by
+                a '.' appearing, e.g. '1' is integer 1, but '1.' is
                 floating-point 1 .
 
     o mixed     A variable allowed to take a value of any type (int,

--- a/doc/efun.de/efun.de
+++ b/doc/efun.de/efun.de
@@ -14,15 +14,13 @@ BESCHREIBUNG
 
            Es steht dem Mud-Betreiber frei, diese Efuns zu deaktivieren.
 
-             assoc()
              break_point()
              db_*()
-             insert_alist()
-             intersect_alist()
+             pg_*()
+             sl_*()
              parse_command()
              process_string()
              rusage()
-             set_is_wizard()
              transfer()
              tls_available()
              tls_check_certificate()
@@ -34,6 +32,8 @@ BESCHREIBUNG
              tls_refresh_certs()
              xml_generate()
              xml_parse()
+             json_serialize()
+             json_parse()
 
          - 'Vorlaeufig'
 

--- a/doc/efun/efun
+++ b/doc/efun/efun
@@ -15,15 +15,13 @@ DESCRIPTION
            A mud's maintainer is free to deactivate these efuns when
            compiling the driver:
 
-             assoc()
              break_point()
              db_*()
-             insert_alist()
-             intersect_alist()
+             pg_*()
+             sl_*()
              parse_command()
              process_string()
              rusage()
-             set_is_wizard()
              transfer()
              tls_available()
              tls_check_certificate()
@@ -35,6 +33,8 @@ DESCRIPTION
              tls_refresh_certs()
              xml_generate()
              xml_parse()
+             json_serialize()
+             json_parse()
 
          - 'preliminary' or 'experimental'
 

--- a/doc/obsolete/add_verb.de
+++ b/doc/obsolete/add_verb.de
@@ -1,4 +1,4 @@
-VERALTET
+ENTFERNTE EFUN
 SYNOPSIS
         void add_verb(string str)
 
@@ -13,6 +13,9 @@ BESCHREIBUNG
 
         [marion Sun Jan 19 1992 Don't use it. This file is retained
         because of somewhat nostalgic reasons.]
+
+GESCHICHTE
+        Entfernt in LDmud 3.3, ersetzt durch add_action().
 
 SIEHE AUCH
         add_action(E), query_verb(E), add_xverb(E), remove_action(E)

--- a/doc/obsolete/add_xverb.de
+++ b/doc/obsolete/add_xverb.de
@@ -1,4 +1,4 @@
-VERALTET
+ENTFERNTE EFUN
 SYNOPSIS
     void add_xverb(string str)
 
@@ -11,6 +11,9 @@ BESCHREIBUNG
         add_xverb() nur die vorangehenden Zeichen der Eingabezeile mit <str>
         uebereinstimmen muessen. Das entspricht im Wesentlichen einer
         add_action() mit gesetzen Flag.
+
+GESCHICHTE
+        Entfernt in LDmud 3.3, ersetzt durch add_action().
 
 SIEHE AUCH
         add_action(E), query_verb(E), add_verb(E)

--- a/doc/obsolete/m_sizeof.de
+++ b/doc/obsolete/m_sizeof.de
@@ -1,4 +1,4 @@
-VERALTET
+ENTFERNTE EFUN
 SYNOPSIS
         int m_sizeof(mapping map)
 
@@ -9,3 +9,4 @@ BESCHREIBUNG
 GESCHICHTE
         Seit LDMud 3.2.9 ist m_sizeof() nur noch verfuegbar, wenn der Treiber
             mit USE_DEPRECATED kompiliert wurde.
+        Entfernt in LDmud 3.3.

--- a/doc/obsolete/set_auto_include_string.de
+++ b/doc/obsolete/set_auto_include_string.de
@@ -1,4 +1,4 @@
-GESCHUETZT, VERALTET
+ENTFERNTE EFUN
 SYNOPSIS
         void set_auto_include_string(string arg)
 
@@ -16,6 +16,7 @@ GESCHICHTE
         LDMud 3.2.9 ersetzte set_auto_include_string() durch den Driver
             Hook H_AUTO_INCLUDE. Diese alte Version ist nur verfuegbar,
             wenn der Treiber mit USE_DEPRECATED kompiliert wurde.
+        Entfernt in LDmud 3.3.
 
 SIEHE AUCH
         set_driver_hook(E), privilege_violation(M), pragma(LPC), master(M)


### PR DESCRIPTION
- efun.de/: add_verb, add_xverb, m_sizeof, set_auto_include_string are obsolete
- efun, efun.de: alists are gone, pg_*(), sl_*(), json_*() are new