### PR TITLE
use sufficient precision for `__FLOAT_MIN__` and `__FLOAT_MAX__`

### DIFF
--- a/src/lex.c
+++ b/src/lex.c
@@ -898,9 +898,9 @@ init_lexer(void)
     add_permanent_define_str("__INT_MAX__", -1, mtext);
     sprintf(mtext, "(%"PRIdPINT")", PINT_MIN);
     add_permanent_define_str("__INT_MIN__", -1, mtext);
-    sprintf(mtext, "(%g)", DBL_MAX);
+    sprintf(mtext, "(%.17g)", DBL_MAX);
     add_permanent_define_str("__FLOAT_MAX__", -1, mtext);
-    sprintf(mtext, "(%g)", DBL_MIN);
+    sprintf(mtext, "(%.17g)", DBL_MIN);
     add_permanent_define_str("__FLOAT_MIN__", -1, mtext);
     sprintf(mtext, "%"PRIdMPINT, get_current_time());
     add_permanent_define_str("__BOOT_TIME__", -1, mtext);


### PR DESCRIPTION
Besides giving more accurate values, this also fixes a warning when `__FLOAT_MIN__` is used ("Floating point number out of range."; whether this happens may depend on the C library and compiler. The error comes from parsing "2.22507e-308" using `strtod`, which results in a underflow into denormals, and whether that is signaled as an error is implementation-defined.)

Unfortunately, this change could break existing code, which might for example use `__FLOAT_MAX__` (say) as a special value and compare it for equality. Such a value might be stored in a save file, and then those comparisons would fail for such values when the driver is updated with this patch. Is this a serious concern? (We actually have zero uses of these macros in our mudlib...)

Should there be a test case? Not sure what to test for, really. The warning, maybe?