### PR TITLE
fix a crash in implode()

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -707,7 +707,7 @@ arr_implode_string (vector_t *arr, string_t *del MTRACE_DECL)
     /* Allocate the string; cop out if there's nothing to implode.
      */
     if (size <= 0)
-        return ref_mstring(STR_EMPTY);
+        return ref_mstring(stringtype == T_STRING ? STR_EMPTY : empty_byte_string);
 
     result = mstring_alloc_string(size MTRACE_PASS);
     if (!result)

--- a/test/t-efuns.c
+++ b/test/t-efuns.c
@@ -521,6 +521,7 @@ mixed *tests = ({
     ({ "implode 1", 0, (: implode(({ "foo", "bar", "" }), "*") == "foo*bar*":) }),
     ({ "implode 2", 0, (: implode(({ "a", 2, this_object(), "c" }), "b") == "abc" :) }),
     ({ "implode 3", 0, (: implode(({ "", "" }), "") == "":) }),
+    ({ "implode 4", 0, (: implode(({ b"" }), b"abc") == b"" :) }),
     ({ "random", 0,
         (:
             /* Let's check every 8 bits for some randomness. */


### PR DESCRIPTION
implode() on bytes would crash whenever the result is empty, for example

  implode(({b""}), b"");

We have to make sure that arr_implode_string returns an empty string of
the right type in this case.