### PR TITLE
Prevent telnet_neg() from advancing beyond the current input

### DIFF
--- a/test/t-0000892.c
+++ b/test/t-0000892.c
@@ -1,0 +1,64 @@
+#include "/inc/base.inc"
+#include "/inc/client.inc"
+
+#include "/sys/input_to.h"
+
+bytes b(string s)
+{
+    return to_bytes(s, "ISO-8859-1");
+}
+
+void run_server()
+{
+    binary_message(b"a\n\nb");
+}
+
+void run_client()
+{
+    input_to("client_input1");
+    call_out("end_client", __ALARM_TIME__);
+}
+
+int step;
+
+void client_input1(string str)
+{
+    step = 1;
+    if (str != "a") {
+        msg("FAILURE: Received %O instead of %O.\n", str, "a");
+        shutdown(1);
+    }
+    input_to("client_input2", INPUT_CHARMODE);
+}
+
+void client_input2(string str)
+{
+    step = 2;
+    if (str != "\n") {
+        msg("FAILURE: Received %O instead of %O.\n", b(str), b("\n"));
+        shutdown(1);
+    } else {
+        msg("Success!\n");
+        shutdown(0);
+    }
+}
+
+void end_client()
+{
+    msg("FAILURE: Received %d/2 messages.\n", step);
+    shutdown(1);
+}
+
+void run_test()
+{
+    msg("\nRunning test for #0000892:\n"
+          "--------------------------\n");
+
+    connect_self("run_server", "run_client");
+}
+
+string *epilog(int eflag)
+{
+    run_test();
+    return 0;
+}

--- a/test/t-comm-receive-bulk.c
+++ b/test/t-comm-receive-bulk.c
@@ -1,0 +1,52 @@
+// Check that we can receive a bunch of lines at once rather than having to
+// wait for the next backend cycle after each line of input.
+
+#include "/inc/base.inc"
+#include "/inc/client.inc"
+
+#include "/sys/input_to.h"
+
+void run_server()
+{
+   write("H\n"*10);
+}
+
+int start;
+
+void run_client()
+{
+    start = time();
+    input_to("client_input", 0, 1);
+}
+
+void client_input(string str, int c)
+{
+    msg("ci " + c + "\n");
+    if (time() - start >= 2 * __ALARM_TIME__) {
+        msg("FAILURE: Took too long to receive 10 lines.\n");
+        shutdown(1);
+        return;
+    }
+
+    if (c == 10) {
+        msg("Success!\n");
+        shutdown(0);
+        return;
+    }
+
+    input_to("client_input", 0, c + 1);
+}
+
+void run_test()
+{
+    msg("\nRunning test for receiving several lines at once:\n"
+          "-------------------------------------------------\n");
+
+    connect_self("run_server", "run_client");
+}
+
+string *epilog(int eflag)
+{
+    run_test();
+    return 0;
+}


### PR DESCRIPTION
telnet_neg() is not only responsible for telnet negotiations but also
deals with line endings. For this to work properly, it checks whether
the interactive is in character mode. Since the mode may be switched
by the current command, it is important not to process input further
beyond that point.

To this end, we split telnet_neg() into two parts, telnet_neg_reset()
that is responsible for switching back to TS_DATA mode, and telnet_neg()
that does the actual processing. This allows resetting the telnet
neg state without further processing. It also makes telnet_neg()
almost idempotent: if called in TS_READY or TS_CHAR_READY state, it
will have no effect.

Fixes #892.