### PR TITLE
mudlib: small bugfixes for query_ip_name and query_ip_number simuls.

### DIFF
--- a/mudlib/deprecated/query_ip_name.c
+++ b/mudlib/deprecated/query_ip_name.c
@@ -12,6 +12,8 @@ varargs string query_ip_name(object player)
     object ob = player;
     ob ||= efun::this_player();
 
+    if(!interactive(ob)) return 0;
+
     player = efun::interactive_info(ob, II_IP_ADDRESS);
     return efun::interactive_info(ob, II_IP_NAME);
 }
@@ -20,6 +22,8 @@ varargs string query_ip_number(object player)
 {
     object ob = player;
     ob ||= efun::this_player();
+
+    if(!interactive(ob)) return 0;
 
     player = efun::interactive_info(ob, II_IP_ADDRESS);
     return efun::interactive_info(ob, II_IP_NUMBER);

--- a/mudlib/deprecated/query_ip_name.c
+++ b/mudlib/deprecated/query_ip_name.c
@@ -7,7 +7,7 @@
 
 #include <interactive_info.h>
 
-varargs string query_ip_name(object player)
+varargs string query_ip_name(object|int* player)
 {
     object ob = player;
     ob ||= efun::this_player();
@@ -18,7 +18,7 @@ varargs string query_ip_name(object player)
     return efun::interactive_info(ob, II_IP_NAME);
 }
 
-varargs string query_ip_number(object player)
+varargs string query_ip_number(object|int* player)
 {
     object ob = player;
     ob ||= efun::this_player();


### PR DESCRIPTION
:wave: Hi folks,

Thanks again for providing the `mudlib/deprecated/` simuls. They were extremely helpful to me.

Here are two small commits that update the `query_ip_number` and `query_ip_name` simuls based on my experience migrating from 3.2.17 to 3.5.4. 

### mudlib: guard query_ip_x simuls for interactives - 84beba5

The deprecated simul backfills for `query_ip_name` and `query_ip_number` exhibit a slight difference in behaviour compared to how the efun counterparts appeared to have worked on 3.2.x.

When given a linkdead non-interactive player object the simuls throw an error where previously the efuns would return 0.

On 3.2.17:
```
Guest (P:1:none) goes linkdead.
lpc return query_ip_name(find_player("guest"));
[55|0.000012s] Result: 0
```

On 3.5.4:
```
Guest (P:1:none) goes linkdead.
lpc return query_ip_name(find_player("guest"));
RUNTIME ERROR (CAUGHT): /secure/simul_efun (/secure/simul/compat/query_ip_name.c) line 16: Bad arg 1 to interactive_info(): Object 'obj/player/player#985' is not interactive.
```

This commit introduces a fix to both simuls by checking if `ob` is `interactive()` before calling `efun::interactive_info` with `ob` as an arg. If a non-interactive `ob` is provided both simuls now return `0`.

### mudlib: fix type of query_ip_x simul player arg. -  e87f0e9

Per discussion with @zesstra the correct type for the `player` argument passed by reference to `query_ip_name` and `query_ip_number` should be `object|int*` to support the legacy behaviour as well as the `interactive_info(ob, II_IP_ADDRESS) ` assignment.

