### PR TITLE
mudlib: fix tail sefun for small files.

### DIFF
--- a/mudlib/deprecated/tail.c
+++ b/mudlib/deprecated/tail.c
@@ -14,7 +14,18 @@ varargs int tail(string file)
 
     if (!stringp(file) || !this_player())
         return 0;
-    bytes txt = read_bytes(file, -(TAIL_MAX_BYTES + 80), (TAIL_MAX_BYTES + 80));
+
+    int size = file_size(file);
+    if (size < 0)
+        return 0;
+
+    int start_offset, end_offset;
+    start_offset = end_offset = TAIL_MAX_BYTES + 80;
+
+    if ((size - start_offset) < 0)
+      start_offset = 0;
+
+    bytes txt = read_bytes(file, -start_offset, end_offset);
     if (!bytesp(txt))
         return 0;
 


### PR DESCRIPTION
Previously the `tail` efun was deprecated and replaced by an optional `mudlib/deprecated/tail.c` simul efun backed by `efun::read_bytes`.

However, when `read_bytes` is given a negative start offset it treats it as an offset from the end of the file. If this offset lands before the beginning of the file, `0` is returned.

Prior to this commit the `tail` simul unconditionally uses `-(TAIL_MAX_BYTES + 80)` as the starting offset (`-1080` bytes by
default). This means for files smaller than `1080` bytes the `read_bytes` call will return `0` and the `tail` simul returns `0`.

With this update we first check the file size of `file` and if `size - (TAIL_MAX_BYTES + 80)` would be `< 0` we use `0` as the starting offset. This allows the simul to handle files smaller than `1080` bytes without error.