### PR TITLE
main: mention JSON support in --options output.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2024,6 +2024,9 @@ options (void)
 #ifdef USE_SQLITE
                               , "SQLite3 supported\n"
 #endif
+#ifdef USE_JSON
+                              , "JSON supported\n"
+#endif
 #ifdef USE_TLS
                               , "TLS supported ("
 #  if defined(HAS_OPENSSL)


### PR DESCRIPTION
### Description

Prior to this commit even when `ldmud` was built with JSON support enabled, it wasn't reported in `ldmud --options` along with other optional features like XML or IPv6 support.

<details>
<summary>Example demonstration:</summary>

LD was built from the tip of master w/ json support enabled, and does in fact link `libjson-c` according to `ldd`:
```
[daniel@noir:~/Code/C/ldmud/src]$ ldd ./ldmud | grep "json"
	libjson-c.so.5 => /nix/store/0v39fn5rnz88bxs4zi0fcc8c2gll0rmw-json-c-0.15/lib/libjson-c.so.5 (0x00007fbc865d1000)
```
However, LDMud's `--options` shows no sign of JSON support:
```
[daniel@noir:~/Code/C/ldmud/src]$ ./ldmud --options
...<snipped>...
        Wizlist: saved in <mudlib>/WIZLIST
       Language: parse_command() enabled
                 process_string() enabled
                 clones initialized by __INIT()
                 obsolete and deprecated efuns enabled
                 convert_charset() via iconv available
                 filenames may contain space characters
                 default regexps: PCRE
       Packages: PCRE 8.44
                 idna supported
                 XML supported (libxml2)
                 IPv6 supported
                 MCCP supported
                 mySQL supported
                 PostgreSQL supported
                 SQLite3 supported
 Runtime limits: max read file size:       50000
 ...<snipped>...
 ```
</details>

This commit updates the main.c implementation of the `--options` output to include a line indicating JSON support when `USE_JSON` is defined.

<details>
<summary>Fix demonstration:</summary>

Building with the commit from this PR applied the `--options` flag works as expected:
```
[daniel@noir:~/Code/C/ldmud/src]$ ./ldmud --options
...<snipped>...
       Language: parse_command() enabled
                 process_string() enabled
                 clones initialized by __INIT()
                 obsolete and deprecated efuns enabled
                 convert_charset() via iconv available
                 filenames may contain space characters
                 default regexps: PCRE
       Packages: PCRE 8.44
                 idna supported
                 XML supported (libxml2)
                 IPv6 supported
                 MCCP supported
                 mySQL supported
                 PostgreSQL supported
                 SQLite3 supported
                 JSON supported
 Runtime limits: max read file size:       50000
 ...<snipped>...
```
</details>