### PR TITLE
pkg-python: handle NULL ob in ldmud_object_create. 

### DIFF
--- a/src/pkg-python.c
+++ b/src/pkg-python.c
@@ -2936,6 +2936,9 @@ ldmud_object_create (object_t* ob)
 {
     ldmud_object_t *self;
 
+    if (ob == NULL)
+        return NULL;
+
     self = (ldmud_object_t *)ldmud_object_type.tp_alloc(&ldmud_object_type, 0);
     if (self == NULL)
         return NULL;

--- a/test/t-python/a.c
+++ b/test/t-python/a.c
@@ -1,0 +1,5 @@
+// Just a small LPC ob that can be loaded by startup.py before master is
+// available.
+int main() {
+  return 1;
+}

--- a/test/t-python/startup.py
+++ b/test/t-python/startup.py
@@ -818,3 +818,7 @@ ldmud.register_hook(ldmud.ON_OBJECT_CREATED, ob_created)
 ldmud.register_hook(ldmud.ON_OBJECT_DESTRUCTED, ob_destroyed)
 
 ldmud.register_efun("python_get_hook_info", get_hook_info)
+
+# Test loading an object before master is available
+lpc_ob = ldmud.Object("a")
+print(f"lpc_ob loaded: {lpc_ob}", file=sys.stderr)


### PR DESCRIPTION
#### Description

See [Mantis bug 902](https://mantis.ldmud.eu/mantis/view.php?id=902)

#### tests: add startup.py ldmud.Object invocation. - d8f1ef68cdd363b2d08b9c32dc95a699426ccf25

It's possible to create a reference to an LPC object from Python using `ldmud.Object("...")` during `startup.py` initialization. Crucially this happens before the master object is fully initialized. With LDMud 3.6.4 this early object reference works as expected. With LDMud 3.6.5 it provokes a segfault.

This commit introduces a unit test that can provoke the segfault with 3.6.5 and ensure a subsequent fix doesn't regress.

####  pkg-python: handle NULL ob in ldmud_object_create. - 3d75c35b921135b9ab197c9f533b5c6eb437ede5

If `ldmud_object_create` is given `object_t *ob == NULL` it should immediately return `NULL` instead of calling `ref_object(ob, ...)`, causing a segfault.

This resolves [Mantis bug 902](https://mantis.ldmud.eu/mantis/view.php?id=902).
