### PR TITLE
Added DI_NUM_SIMUL_EFUNS to driver_info()

### DIFF
--- a/doc/efun/driver_info
+++ b/doc/efun/driver_info
@@ -668,7 +668,7 @@ DESCRIPTION
 
 
 
-        Status texts:
+      Status texts:
 
         <what> == DI_STATUS_TEXT_MEMORY:
           A printable string containing information about
@@ -689,6 +689,13 @@ DESCRIPTION
         <what> == DI_STATUS_TEXT_MALLOC_EXTENDED:
           A printable strings with extended memory statistics
           (if the driver was compiled with them).
+
+
+      Misc Status:
+
+        <what> == DI_NUM_SIMUL_EFUNS_TABLED:
+          The number of known simul_efuns (active or not) in the simul_efun
+          table.
 
 
 HISTORY

--- a/mudlib/sys/driver_info.h
+++ b/mudlib/sys/driver_info.h
@@ -191,6 +191,9 @@
 #define DI_STATUS_TEXT_MALLOC                               -703
 #define DI_STATUS_TEXT_MALLOC_EXTENDED                      -704
 
+/* Misc Status */
+#define DI_NUM_SIMUL_EFUNS_TABLED                           -900
+
 /* Indices into the subarrays of DI_MEMORY_EXTENDED_STATISTICS (if given) */
 
 #define DIM_ES_MAX_ALLOC   0

--- a/src/efuns.c
+++ b/src/efuns.c
@@ -126,6 +126,7 @@
 #include "sha1.h"
 #include "stdstrings.h"
 #include "simulate.h"
+#include "simul_efun.h"
 #include "strfuns.h"
 #include "structs.h"
 #ifdef USE_TLS
@@ -10039,6 +10040,10 @@ f_driver_info (svalue_t *sp)
             }
             break;
         }
+
+        case DI_NUM_SIMUL_EFUNS_TABLED:
+            sefun_driver_info(&result, what);
+            break;
     }
 
     /* Clean up the stack and return the result */

--- a/src/simul_efun.c
+++ b/src/simul_efun.c
@@ -49,6 +49,8 @@
 #include "xalloc.h"
 #include "pkg-python.h"
 
+#include "../mudlib/sys/driver_info.h"
+
 /*-------------------------------------------------------------------------*/
 
 object_t *simul_efun_object  = NULL;
@@ -495,6 +497,28 @@ get_simul_efun_header (ident_t* name)
         return &simul_efun_table[name->u.global.sim_efun].function;
     }
 } /* get_simul_efun_header() */
+
+/*-------------------------------------------------------------------------*/
+void
+sefun_driver_info (svalue_t *svp, int value)
+
+/* Returns the simul_efun information for driver_info(<what>).
+ * <svp> points to the svalue for the result.
+ */
+
+{
+    switch (value)
+    {
+        case DI_NUM_SIMUL_EFUNS_TABLED:
+            put_number(svp, num_simul_efun);
+            break;
+
+        default:
+            fatal("Unknown option for sefun_driver_info(): %d\n", value);
+            break;
+    }
+
+} /* sefun_driver_info() */
 
 /*-------------------------------------------------------------------------*/
 #ifdef GC_SUPPORT

--- a/src/simul_efun.h
+++ b/src/simul_efun.h
@@ -50,6 +50,7 @@ extern void invalidate_simul_efuns (void);
 extern Bool assert_simul_efun_object(void);
 extern string_t *query_simul_efun_file_name(void);
 extern function_t *get_simul_efun_header(ident_t* name) __attribute__((nonnull));
+extern void sefun_driver_info (svalue_t *svp, int value) __attribute__((nonnull(1)));
 
 #ifdef GC_SUPPORT
 extern void clear_simul_efun_refs(void);

--- a/test/t-sefun/test.c
+++ b/test/t-sefun/test.c
@@ -2,6 +2,8 @@
 #include "/inc/msg.inc"
 #include "/inc/testarray.inc"
 
+#include "/sys/driver_info.h"
+
 mixed* fun(string arg, int num)
 {
     return ({arg, num});
@@ -13,6 +15,11 @@ void run_test()
           "-----------------------------\n");
 
     return run_array(({
+        ({ "Check number of tabled sefuns", 0,
+            (:
+                return driver_info(DI_NUM_SIMUL_EFUNS_TABLED) == 65534;
+            :)
+        }),
         ({ "Calling sefun0000", 0,
             (:
                 return sefun0000() == 0;


### PR DESCRIPTION
Added info about the number of simul_efuns (active or not) in
the simul_efun table (simul_efun_table).

Some admins may find this interesting to verify that they stay
below the limit for creating real closures to sefuns (currently
2048).