### PR TITLE
Documents format version 3.

### DIFF
--- a/doc/efun.de/restore_object.de
+++ b/doc/efun.de/restore_object.de
@@ -42,7 +42,8 @@ GESCHICHTE
             NonLambda-Closures, Symbole und gequotete Arrays zu laden,
             indem ein neues Format fuer das Savefile verwendet wird.
         LDMud 3.5.0 unterstuetzt das Einlesen von Formatversion 2 mit hoeherer
-            Praezision der Gleitkommazahlen.
+            Praezision der Gleitkommazahlen und Formatversion 3 um
+	    lvalue-Referenzen einzulesen.
 
 SIEHE AUCH
         save_object(E), restore_value(E), valid_read(M)

--- a/doc/efun.de/save_object.de
+++ b/doc/efun.de/save_object.de
@@ -27,7 +27,9 @@ BESCHREIBUNG
              2: LDMUd >= 3.5.0: Gleitkommazahlen werden in einem neuen Format
                 geschrieben, welches kompakter ist die Gleitkommazahlen aus
                 3.5.x verlustfrei speichern kann.
-        
+	     3: LDMud >= 3.5.0: kann zusaetzlich lvalue-Referenzen speichern
+	        (ohne werden stattdessen einfache rvalues gespeichert)
+
         Es wird empfohlen, die Angabe des Formats wegzulassen oder in Version
         2 (oder hoeher) zu speichern.
 
@@ -43,7 +45,7 @@ GESCHICHTE
             Closures, Symbolen und gequoteten Arrays. Dazu wurde ein neues
             Format fuer die Speicherdatei eingefuehrt.
         LDMud 3.2.10 fuehrte das Argument <format> ein.
-        LDMud 3.5.0 fuehrte Formatversion 2 ein.
+        LDMud 3.5.0 fuehrte Formatversionen 2 und 3 ein.
 
 SIEHE AUCH
         restore_object(E), save_value(E)

--- a/doc/efun/restore_object
+++ b/doc/efun/restore_object
@@ -39,7 +39,7 @@ HISTORY
         LDMud 3.2.9 added the restoring of non-lambda closures, symbols,
         and quoted arrays, using a new savefile format version.
         LDMud 3.5.0 added the possibility to restore version 2 with its higher
-        float precision.
-        
+        float precision and version 3 with lvalue references.
+
 SEE ALSO
         save_object(E), restore_value(E), valid_read(M)

--- a/doc/efun/save_object
+++ b/doc/efun/save_object
@@ -22,11 +22,13 @@ DESCRIPTION
             0: original format, used by Amylaar LPMud and LDMud <= 3.2.8 .
             1: LDMud >= 3.2.9: non-lambda closures, symbols, quoted arrays
                  can be saved.
-            2: LDMUd >= 3.5.0: floats are stored in a different way, which is
-                 more compact and can store the new floats losslessly.                 
+            2: LDMud >= 3.5.0: floats are stored in a different way, which is
+                 more compact and can store the new float losslessly.
+	    3: LDMud >= 3.5.0: can also save lvalues references (without it,
+	         the plain rvalue will be saved).
 
-        It is recommended to use version 2 or higher.
-        
+        It is recommended to use version 3 or higher.
+
         A variable is considered 'saveable' if it is not declared
         as 'nosave' or 'static'.
 
@@ -39,7 +41,7 @@ HISTORY
         LDMud 3.2.9 added the saving of non-lambda closures, symbols,
           and quoted arrays, using the new savefile format version 1.
         LDMud 3.2.10 added the <format> argument.
-        LDMud 3.5.0 added savefile format version 2.
+        LDMud 3.5.0 added savefile format version 2 and 3.
 
 SEE ALSO
         restore_object(E), save_value(E)


### PR DESCRIPTION
Format version 3 was added in 3.5.0 and enables to save and restore
lvalue references.