### PR TITLE
Feature/flexible terminal colour

### DIFF
--- a/doc/efun.de/terminal_colour.de
+++ b/doc/efun.de/terminal_colour.de
@@ -1,12 +1,15 @@
 SYNOPSIS
         varargs string terminal_colour(string str,
                                        null | mapping | closure map,
-                                       int wrap, int indent)
+                                       [int wrap, int indent,]
+                                       [string delimiter, int code_length])
 BESCHREIBUNG
         Ist <map> ein Wert ungleich 0, ersetzt diese Efun alle Farb-
-        Definitionen der Form "%^KEY%^" (siehe unten fuer Details) im
-        String <str> und ersetzt sie durch die entsprechenden Werte aus dem
-        unter <map> angegebenen Farbschluessel.
+        Definitionen der Form "%^KEY%^" im String <str> und ersetzt sie
+        durch die entsprechenden Werte aus dem unter <map> angegebenen
+        Farbschluessel.
+        Dieses Verhalten kann modifiziert werden indem delimiter und
+        code_length uebergeben werden (siehe unten).
 
         Ist <map> ein Mapping, muessen die Eintraege das Format
         "KEY" : "wert" haben; Eintraege, die keine Strings enthalten,
@@ -20,9 +23,6 @@ BESCHREIBUNG
         Ist <map> eine Closure, wird diese mit den Farbdefinitionen <KEY>
         als Argument aufgerufen und muss einen String zurueck liefern, der
         die <KEY>s ersetzt.
-
-        Die speziellen Schluessel "%^%^" und "%%^^" werden immer durch das
-        Literal "%^" ersetzt.
 
         Die Parameter <wrap> und <indent> sind optional. Ist nur <wrap>
         angegeben, wird <str> in der Spalte <wrap> umgebrochen. Ist
@@ -40,11 +40,15 @@ BESCHREIBUNG
         wirkt als einfache Zeilenumbruch Funktion.
 
 
-        ERKENNEN VON FARBDEFINITIONEN
+        STANDARDSTRATEGIE ZUM ERKENNEN VON FARBDEFINITIONEN
 
-        Wie bereits erwaehnt, werden die speziellen Schluessel "%^%^" und
-        "%%^^" durch das Literal "%^" ersetzt und spielen im Weiteren
-        keine Rolle.
+        Standardmaessig sucht terminal_colour() nach Farb-Definitionen, die
+        von zwei Trennern der Form "%^" umschlossen sind. Dieses Verhalten
+        kann jedoch modifiziert werden indem alternative Werte fuer 
+        delimiter und code_length uebergeben werden (siehe unten).
+
+        Der spezielle Schluessel "%^%^" wird durch das Literal "%^" ersetzt
+        und spielt im Weiteren keine Rolle.
 
         Fuer den Eingabestring wird das folgende Format vorausgesetzt:
 
@@ -70,7 +74,21 @@ BESCHREIBUNG
           }
 
 
-BEISPIELE
+        MODIFIZIEREN DER ERSETZUNGSSTRATEGIE
+
+        Die Ersetzungsstrategie kann mittels alternativer Werte fuer
+        delimiter udn code_length veraendert werden.
+
+        'delimiter' ist der Trenner (Standard "%^") und 'code_length'
+        bestimmt die Laenge der Farb-Codes. Der Standardwert 0 bedeutet
+        dabei "variable Laenge, von Trennern umschlossen". Jede andere Zahl
+        behandelt entsprechend viele Zeichen nach dem Trenner als Farbcode;
+        in diesem Fall ist _kein_ abschliessender Trenner noetig.
+
+        Doppelte Trenner werden dabei wieder durch eine Kopie des Trenners
+        selbst ersetzt.
+
+BEISPIELE (STANDARDVERHALTEN)
         mapping trans;
         string str;
 
@@ -112,6 +130,14 @@ BEISPIELE
 
             "dies ist die erste Zeile\n   und dies ist die zweite Zeile"
 
+BEISPIELE (MODIFIZIERTE KONFIGURATION)
+        trans = ([ "g" : "ansi-green", "b" : "ansi-blue" ]);
+
+        str = terminal_colour( "^g and ^r^^ and ^b", trans, "^", 1 );
+
+        Dies fuehrt zu str == "ansi-green and ^ and ansi-blue"
+
+
 GESCHICHTE
         Die Idee fuer diese Efun und die erste Implementierung stammen
         aus MudOS; die Strategie fuer das Erkennen von Schluesseln
@@ -121,6 +147,9 @@ GESCHICHTE
         von Farbschluesseln hinzu. Es erklaerte zudem offiziell das
         Verhalten betreffen "%%^^" aus Gruenden besserer Kompatibilitaet
         mit MudOS.
+        LDMud 3.7.0 fuegte die Konfigurierbarkeit von Trennern hinzu und
+        entfernte die Unterstuetzung von "%%^^" (verwende die mit dem
+        Source bereitgestellte sefun falls noetig).
 
 SIEHE AUCH
         sprintf(E)

--- a/doc/efun.de/terminal_colour.de
+++ b/doc/efun.de/terminal_colour.de
@@ -1,8 +1,8 @@
 SYNOPSIS
         varargs string terminal_colour(string str,
-                                       null | mapping | closure map,
-                                       [int wrap, int indent,]
-                                       [string delimiter, int code_length])
+                                null | mapping | closure map,
+                                [int wrap, int indent,]
+                                [string delimiter, int|string end_delimiter])
 BESCHREIBUNG
         Ist <map> ein Wert ungleich 0, ersetzt diese Efun alle Farb-
         Definitionen der Form "%^KEY%^" im String <str> und ersetzt sie
@@ -12,9 +12,9 @@ BESCHREIBUNG
         code_length uebergeben werden (siehe unten).
 
         Ist <map> ein Mapping, muessen die Eintraege das Format
-        "KEY" : "wert" haben; Eintraege, die keine Strings enthalten,
-        werden ignoriert. Einzige Ausnahme dazu: enthaelt <map> einen
-        Eintrag der Form 0:wert, wird dieser fuer alle Farbdefinitionen
+        ([ "KEY" : "wert" ]) haben; Eintraege, die keine Strings enthalten,
+        werden ignoriert. Einzige Ausnahme dazu: enthaelt <map> einen Eintrag
+        der Form ([ 0 : "wert" ]), wird dieser fuer alle Farbdefinitionen
         verwendet, die keinem anderen Schluessel zugeordnet werden koennen.
         <wert> kann in diesem Fall ein String oder eine Closure sein. Handelt
         es sich um eine Closure, erhaelt diese den <KEY> als Argument und
@@ -77,23 +77,29 @@ BESCHREIBUNG
         MODIFIZIEREN DER ERSETZUNGSSTRATEGIE
 
         Die Ersetzungsstrategie kann mittels alternativer Werte fuer
-        delimiter udn code_length veraendert werden.
+        delimiter und end-delimiter veraendert werden.
 
-        'delimiter' ist der Trenner (Standard "%^") und 'code_length'
-        bestimmt die Laenge der Farb-Codes. Der Standardwert 0 bedeutet
-        dabei "variable Laenge, von Trennern umschlossen". Jede andere Zahl
-        behandelt entsprechend viele Zeichen nach dem Trenner als Farbcode;
-        in diesem Fall ist _kein_ abschliessender Trenner noetig.
+        'delimiter' ist der Trenner (Standard "%^").
+        'end_delimiter' legt fest wie die Zeichen danach behandelt werden.
+        Es kann entweder ein integer sein, der eine feste Laenge fuer den
+        Farb-Code angibt, oder ein String, der als End-Trenner verwendet
+        werden soll.
+        Der Standardwert 0 bedeutet dabei "variable Laenge, von zwei gleichen
+        Trennern umschlossen" (also das Standardverhalten mit
+        "<Trenner><Farbcode><Trenner>").
+        Jede positive Zahl behandelt entsprechend viele Zeichen nach dem
+        Trenner als Farbcode; in diesem Fall ist _kein_ abschliessender
+        Trenner noetig.
 
-        Doppelte Trenner werden dabei wieder durch eine Kopie des Trenners
-        selbst ersetzt.
+        Eine Sequenz aus einem direkt aufeinanderfolgenden Paar von Trenner
+        und End-Trenner (oder ein doppelter Trenner falls die beiden gleich
+        sind) wird dabei wieder durch eine Kopie des Trenners selbst ersetzt.
 
 BEISPIELE (STANDARDVERHALTEN)
         mapping trans;
         string str;
 
         trans = ([ "GREEN" : "ansi-green", "RED" : "", "BLUE" : 1 ]);
-
         str = terminal_colour( "%^GREEN%^ and %^RED%^ and %^BLUE%^", trans );
 
         Dies fuehrt zu str == "ansi-green and  and BLUE".
@@ -131,11 +137,36 @@ BEISPIELE (STANDARDVERHALTEN)
             "dies ist die erste Zeile\n   und dies ist die zweite Zeile"
 
 BEISPIELE (MODIFIZIERTE KONFIGURATION)
-        trans = ([ "g" : "ansi-green", "b" : "ansi-blue" ]);
 
+    Fixe Codelaenge:
+        trans = ([ "g" : "ansi-green", "b" : "ansi-blue" ]);
         str = terminal_colour( "^g and ^r^^ and ^b", trans, "^", 1 );
 
-        Dies fuehrt zu str == "ansi-green and ^ and ansi-blue"
+        Dies fuehrt zu str == "ansi-green and r^ and ansi-blue".
+        "^r" wurde nicht uebersetzt, da es keinen Eintrag "r" oder 0 im
+        Mapping gibt.
+
+    XML-Stil fuer Farbcodes:
+        str = terminal_colour( "<g> and <r> are <> than <b>", trans, "<", ">" )
+
+        Ergibt str == "ansi-green and r are < than ansi-blue".
+
+    Decodieren von ANSI-Farbcodes mittels verschiedner Start- und End-Trenner:
+        trans = ([ "31" : "(ansi-red)", "1" : "(ansi-hilite)",
+                "0" : "(ansi-reset)" ]);
+        str = terminal_colour( "\e[31mRoter Text\e[0m", trans, "\e[", "m" );
+
+        Dies ergibt str == "(ansi-red)Roter Text(ansi-reset)".
+
+    Decodieren von zusammengesetzten ANSI-Codes:
+        str = terminal_colour( "\e[31;1mHellroter Text\e[0m",
+               (: implode(map(explode($1, ";"),
+                              (: trans[$1] || "" :)
+                             ), "")
+                :),
+                "\e[", "m" );
+
+        Ergibt str == "(ansi-red)(ansi-hilite)Hellroter Text(ansi-reset)".
 
 
 GESCHICHTE
@@ -149,7 +180,7 @@ GESCHICHTE
         mit MudOS.
         LDMud 3.7.0 fuegte die Konfigurierbarkeit von Trennern hinzu und
         entfernte die Unterstuetzung von "%%^^" (verwende die mit dem
-        Source bereitgestellte sefun falls noetig).
+        Source bereitgestellte simul-efun falls noetig).
 
 SIEHE AUCH
         sprintf(E)

--- a/doc/efun/terminal_colour
+++ b/doc/efun/terminal_colour
@@ -1,12 +1,15 @@
 SYNOPSIS
         varargs string terminal_colour(string str, null|mapping|closure map,
-                                       int wrap, int indent)
+                                       [int wrap, int indent,]
+                                       [string delimiter, int code_length])
 
 DESCRIPTION
         If <map> is given as a non-0 value, this efun expands all
-        colour-defines of the form "%^KEY%^" (see below for details) from the
-        input-string and replaces them by the apropriate values found
-        for the color-key specified by <map>.
+        colour-defines of the form "%^KEY%^" from the input-string and
+        replaces them by the apropriate values found for the color-key
+        specified by <map>.
+        This behaviour can be modified by providing alternative values 
+        for delimiter and code_length (see below).
 
         If <map> is a mapping, the entries queries have the
         format "KEY" : "value", non-string contents are ignored with one
@@ -17,9 +20,6 @@ DESCRIPTION
 
         If <map> is given as a closure, it is called with the KEYs to
         replace, and has to return the replacement string.
-
-        The special keys "%^%^" and "%%^^" are always replaced with the
-        literal "%^".
 
         The parameters wrap and indent are both optional, if only wrap is
         given then the str will be linewrapped at the column given with
@@ -37,11 +37,14 @@ DESCRIPTION
         provided by sprintf("%-=s").
 
 
-        KEY RECOGNITION STRATEGY
+        DEFAULT KEY RECOGNITION STRATEGY
 
-        As mentioned above, the special keys "%^%^" and "%%^^" are always
-        replaced with the literal "%^" and play no role in the following
-        considerations.
+        By default terminal_colour searches for colour-defined enclosed
+        by the key "%^". This behaviour can be changed by providing
+        values for delimiter and code_length (see below).
+
+        The special key "%^%^" is always replaced with the literal "%^"
+        and plays no role in the following considerations.
 
         The input string is supposed to follow this syntax:
 
@@ -66,7 +69,23 @@ DESCRIPTION
                                   , ext, w, i);
           }
 
-EXAMPLES
+
+        MODIFYING THE KEY RECOGNITION STRATEGY
+
+        The matching strategy can be configured by providing alternative
+        values for delimiter and code_lenfgth.
+
+        'delimiter' is the delimter to use for matching (default "%^") and
+        'code_length' determines the length of the colour codes. The default
+        value is 0, meaning "variable length, enclosed between delimiters".
+        Any other number will treat as many characters after a delimiter as
+        colour code, requiring _no_ closing delimiter.
+
+        Duplicate delimiters will again be replaced with a literal copy of
+        the delimiter.
+
+
+EXAMPLES (DEFAULT BEHAVIOUR)
         mapping trans;
         string str;
 
@@ -103,6 +122,15 @@ EXAMPLES
 
             "this is the first line\n   and this is the indented second one"
 
+
+EXAMPLES (MODIFIED BEHAVIOUR)
+        trans = ([ "g" : "ansi-green", "b" : "ansi-blue" ]);
+
+        str = terminal_colour( "^g and ^r^^ and ^b", trans, "^", 1 );
+
+        This will result in str == "ansi-green and ^ and ansi-blue"
+
+
 HISTORY
         Efun idea and initial implementation taken from MudOS; the key
         recognition strategy (including pure wrapping mode) was straightened
@@ -111,6 +139,8 @@ HISTORY
         mappings.
         LDMud 3.2.9/3.3.102 officialized the "%%^^" replacement pattern for
         better MudOS compatibility.
+        LDMud 3.7.0 introduced configurable delimiters and dropped support
+        for the "%%^^" replacement pattern (use provided sefun if needed).
 
 SEE ALSO
         sprintf(E)

--- a/doc/efun/terminal_colour
+++ b/doc/efun/terminal_colour
@@ -1,7 +1,8 @@
 SYNOPSIS
-        varargs string terminal_colour(string str, null|mapping|closure map,
-                                       [int wrap, int indent,]
-                                       [string delimiter, int code_length])
+        varargs string terminal_colour(string str,
+                                null|mapping|closure map,
+                                [int wrap, int indent,]
+                                [string delimiter, int|string end_delimiter])
 
 DESCRIPTION
         If <map> is given as a non-0 value, this efun expands all
@@ -12,11 +13,11 @@ DESCRIPTION
         for delimiter and code_length (see below).
 
         If <map> is a mapping, the entries queries have the
-        format "KEY" : "value", non-string contents are ignored with one
-        exception: if the mapping contains an entry 0:value, it is used
-        for all otherwise unrecognized keys. The value in this case can be
-        a string, or a closure. If it is a closure, it takes the key as
-        argument and has to return the replacement string.
+        format ([ "KEY" : "value" ]), non-string contents are ignored with
+        one exception: if the mapping contains an entry ([ 0 : value ]), it
+        is used for all otherwise unrecognized keys. The value in this case
+        can be a string, or a closure. If it is a closure, it takes the key
+        as argument and has to return the replacement string.
 
         If <map> is given as a closure, it is called with the KEYs to
         replace, and has to return the replacement string.
@@ -73,16 +74,22 @@ DESCRIPTION
         MODIFYING THE KEY RECOGNITION STRATEGY
 
         The matching strategy can be configured by providing alternative
-        values for delimiter and code_lenfgth.
+        values for delimiters and code_length.
 
-        'delimiter' is the delimter to use for matching (default "%^") and
-        'code_length' determines the length of the colour codes. The default
-        value is 0, meaning "variable length, enclosed between delimiters".
-        Any other number will treat as many characters after a delimiter as
-        colour code, requiring _no_ closing delimiter.
+        'delimiter' is the delimter to use for matching (default "%^").
+        'end_delimiter' determines how the following characters are to be
+        interpreted. It can either be an integer, denoting a fixed color key
+        length after the delimiter, or a string containing an end-delimiter.
+        The default value is 0, meaning "variable length, enclosed between
+        two equal delimiters" (i.e. the default "<delim><colorkey><delim>"
+        behaviour).
+        Any positive number will treat as many characters after a delimiter as
+        colour-key, requiring _no_ closing delimiter.
 
-        Duplicate delimiters will again be replaced with a literal copy of
-        the delimiter.
+        A delimiter followed immediately by an end-delimiter (or a duplicate
+        delimiter if the two are identical, or a fixed colorkey length is
+        used) will again be replaced with a literal copy of the delimiter.
+
 
 
 EXAMPLES (DEFAULT BEHAVIOUR)
@@ -90,7 +97,6 @@ EXAMPLES (DEFAULT BEHAVIOUR)
         string str;
 
         trans = ([ "GREEN" : "ansi-green", "RED" : "", "BLUE" : 1 ]);
-
         str = terminal_colour( "%^GREEN%^ and %^RED%^ and %^BLUE%^", trans );
 
         This will result in str == "ansi-green and  and BLUE"
@@ -124,11 +130,36 @@ EXAMPLES (DEFAULT BEHAVIOUR)
 
 
 EXAMPLES (MODIFIED BEHAVIOUR)
-        trans = ([ "g" : "ansi-green", "b" : "ansi-blue" ]);
 
+    Fixed length:
+        trans = ([ "g" : "ansi-green", "b" : "ansi-blue" ]);
         str = terminal_colour( "^g and ^r^^ and ^b", trans, "^", 1 );
 
-        This will result in str == "ansi-green and ^ and ansi-blue"
+        This will result in str == "ansi-green and r^ and ansi-blue". Note
+        that "^r" was not translated because there is no key "r" and no 0-key
+        in the map.
+
+    XML-style color codes:
+        str = terminal_colour( "<g> and <r> are <> than <b>", trans, "<", ">" )
+
+        Results in str == "ansi-green and r are < than ansi-blue".
+
+    Decoding ANSI colors with differing delimiters:
+        trans = ([ "31" : "(ansi-red)", "1" : "(ansi-hilite)",
+                "0" : "(ansi-reset)" ]);
+        str = terminal_colour( "\e[31mRed text\e[0m", trans, "\e[", "m" );
+
+        This will result in str == "(ansi-red)Red text(ansi-reset)".
+
+    Decoding compound ANSI-Codes:
+        str = terminal_colour( "\e[31;1mBright-red text\e[0m",
+               (: implode(map(explode($1, ";"),
+                              (: trans[$1] || "" :)
+                             ), "")
+                :),
+                "\e[", "m" );
+
+        Yields str == "(ansi-red)(ansi-hilite)Bright-red text(ansi-reset)".
 
 
 HISTORY
@@ -139,8 +170,8 @@ HISTORY
         mappings.
         LDMud 3.2.9/3.3.102 officialized the "%%^^" replacement pattern for
         better MudOS compatibility.
-        LDMud 3.7.0 introduced configurable delimiters and dropped support
-        for the "%%^^" replacement pattern (use provided sefun if needed).
+        LDMud 3.7.0 introduced configurable delimiters and dropped support for
+        the "%%^^" replacement pattern (use provided simul-efun if needed).
 
 SEE ALSO
         sprintf(E)

--- a/mudlib/deprecated/terminal_colour.c
+++ b/mudlib/deprecated/terminal_colour.c
@@ -1,0 +1,17 @@
+/* This sefun is to provide a replacement for terminal_colour() that
+ * restores compatibility with the "%%^^" replacement pattern
+ */
+
+#if __EFUN_DEFINED__(terminal_colour)
+
+#include <regexp.h>
+
+varargs string terminal_colour(string str, mapping|closure trans,
+        int wrap, int indent)
+{
+    return efun::terminal_colour(
+            efun::regreplace(str, "%%\\^\\^", "%^%^", RE_GLOBAL),
+            trans, wrap, indent);
+}
+
+#endif

--- a/src/efuns.c
+++ b/src/efuns.c
@@ -3314,7 +3314,7 @@ v_terminal_colour (svalue_t *sp, int num_arg)
  *
  *   varargs string terminal_colour( string str, mapping|closure map,
  *                                   [int wrap, int indent,]
- *                                   string delimiter, int code_len )
+ *                                   string delimiter, string|int end_delimiter )
  *
  * Expands all colour-defines from the input-string and replaces them by the
  * apropriate values found for the color-key inside the given mapping. The
@@ -3334,6 +3334,9 @@ v_terminal_colour (svalue_t *sp, int num_arg)
  * then the str will be linewrapped at the column given with wrap.  If indent
  * is given too, then all wrapped lines will be indented with the number of
  * blanks specified with indent.
+ *
+ * <delimiter> and <end_delimiter> can be used to modify the matching of
+ * colour keys. See manpage for details.
  *
  * The wrapper itself ignores the length of the color macros and that what
  * they contain, it wraps the string based on the length of the other chars

--- a/src/func_spec
+++ b/src/func_spec
@@ -438,7 +438,7 @@ string  sprintf(string, ...);
 int     sscanf(string, string, &&...);
 int     strstr(string|bytes, string|bytes, int default: F_CONST0);
 int     strrstr(string|bytes, string|bytes, int default: F_NCONST1);
-string  terminal_colour(string, null|mapping|closure, void|int|string, void|int|string, void|int|string, void|int );
+string  terminal_colour(string, null|mapping|closure, void|int|string, void|int|string, void|int|string, void|int|string );
 int     text_width(string);
 string  trim(string, void|int, void|int|string);
 string  upper_case(string);

--- a/src/func_spec
+++ b/src/func_spec
@@ -438,7 +438,7 @@ string  sprintf(string, ...);
 int     sscanf(string, string, &&...);
 int     strstr(string|bytes, string|bytes, int default: F_CONST0);
 int     strrstr(string|bytes, string|bytes, int default: F_NCONST1);
-string  terminal_colour(string, null|mapping|closure, void|int, void|int );
+string  terminal_colour(string, null|mapping|closure, void|int|string, void|int|string, void|int|string, void|int );
 int     text_width(string);
 string  trim(string, void|int, void|int|string);
 string  upper_case(string);

--- a/src/settings/beutelland
+++ b/src/settings/beutelland
@@ -14,6 +14,7 @@ with_time_to_reset=3600
 with_alarm_time=1
 
 # --- Swap ---
+with_swap_file=Swap_File
 with_time_to_swap=-1
 with_time_to_swap_variables=-1
 
@@ -44,8 +45,6 @@ enable_eval_cost_trace=yes
 enable_use_parse_command=no
 enable_use_mysql=no
 enable_use_pcre=no
-with_erq_dir=/RoleMUD/bin
-with_swap_file=Swap_File
 
 # --- Wizlist ---
 with_wizlist_file=no

--- a/test/t-efuns.c
+++ b/test/t-efuns.c
@@ -1914,6 +1914,20 @@ mixed *tests = (this_object() == blueprint()) &&
     ({ "variable_list 5", 0, (: variable_list(this_object(), RETURN_VARIABLE_VALUE)[3] == b"\x00" :) }),
     ({ "variable_list 6", 0, (: deep_eq(variable_list(this_object(), RETURN_FUNCTION_LPCTYPE), ({ [string*],                  [mapping],       [string],          [bytes],          [string],       [mixed],      [object],    [string],         [mixed],          [mixed*],                  [mixed*],                  [int] })) :) }),
 
+    ({ "terminal_colour (default) 1", 0, (: terminal_colour("%^foo%^bar%^baz%^", ([ "foo": "#", 0: "*" ])) == "#bar*" :) }),
+    ({ "terminal_colour (default) 2", 0, (: terminal_colour("%^foo%^%^bar%^baz", ([ "foo": "#", "bar": "*" ])) == "#*baz" :) }),
+    ({ "terminal_colour (default) 3", 0, (: terminal_colour("%^foo%^%^%^bar%^baz%^%^", ([ "foo": "#", "bar": "*" ])) == "#%^barbaz" :) }),
+    ({ "terminal_colour (default) 4", 0, (: terminal_colour("%^foo%^%^%^bar%^baz%^%^", ([ "foo": "#", 0: "*" ])) == "#%^bar*" :) }),
+    ({ "terminal_colour (default) 5", 0, (: terminal_colour("%^foo%^%^%^%^^%^%^%^", ([ "foo": "#", 0: "*" ])) == "#%^*%^" :) }),
+    ({ "terminal_colour (default) buffer resize", 0, (: terminal_colour("%^foo%^bar%^%^"*20, ([ "foo": "#", 0: "*" ])) == "#bar%^"*20 :) }),
+    ({ "terminal_colour (default) no colour", 0, (: terminal_colour("foobar", ([ "foo": "#", 0: "*" ])) == "foobar" :) }),
+    ({ "terminal_colour (fixed length) 1", 0, (: terminal_colour("^Xbar^Y", ([ "X": "#", 0: "*" ]), "^", 1) == "#bar*" :) }),
+    ({ "terminal_colour (fixed length) 2", 0, (: terminal_colour("^Xfoo^Ybar^Z", ([ "X": "#", "Y": "*" ]), "^", 1) == "#foo*barZ" :) }),
+    ({ "terminal_colour (fixed length) 3", 0, (: terminal_colour("^Xfoo^^Zbar^Y^", ([ "X": "#", "Y": "*" ]), "^", 1) == "#foo^Zbar*" :) }),
+    ({ "terminal_colour (fixed length) 4", 0, (: terminal_colour("^Xfoo^^Zbar^Yrestofstring", ([ "Z": "#", 0: "*" ]), "^", 1) == "*foo^Zbar*restofstring" :) }),
+    ({ "terminal_colour (fixed length) 5", 0, (: terminal_colour("^^^Xfoo^Y^^^", ([ "X": "#", 0: "*" ]), "^", 1) == "^#foo*^" :) }),
+    ({ "terminal_colour (fixed length) buffer resize", 0, (: terminal_colour("^X^Yfoo^X^Y"*10, ([ "X": "#", 0: "*" ]), "^", 1) == "#*foo#*"*10 :) }),
+
 #ifdef __JSON__
     ({ "json_parse/_serialize 1", 0,
         (: json_parse(json_serialize(1) ) == 1:) }),


### PR DESCRIPTION
This is a rework/cleanup of (the first part of) efun::terminal_colour().

It allows to configure the matching strategy for colour keys by changing the delimiter string and using variable-length (enclosed by two delimiters) or fixed-length (following a single delimiter) colour codes. The configuration can either be done at compile time using --with-tc-delimiter and --with-tc-code-len, on startup with corresponding CLI parameters, or at runtime with configure_driver(DC_TERMINAL_COLOUR, ({ <"delimiter">, <code_len> })).

It removes support for the "%%^^" variant of escaping the colour key though, as this was a major clutter in the code. Support can easily be restored by using the provided sefun in mudlib/deprecated/ if someone really needs this variant.