### PR TITLE
lp-245: fix misc warnings in preloaded code.

### DIFF
--- a/mud/lp-245/notes.txt
+++ b/mud/lp-245/notes.txt
@@ -1,0 +1,3 @@
+Apr 24 20:17:15 lpc start.sh[6835]: /obj/telopt.c:telopt_negotiate "action = 254 option = 46 optdata = 0"
+Apr 24 20:17:25 lpc start.sh[6835]: /obj/telopt.c:telopt_negotiate "action = 253 option = 6 optdata = 0"
+Apr 24 20:17:25 lpc start.sh[6835]: /obj/telopt.c:telopt_negotiate "action = 253 option = 6 optdata = 0"

--- a/mud/lp-245/obj/door.c
+++ b/mud/lp-245/obj/door.c
@@ -497,6 +497,8 @@ int unlock( string str)
     unlock_door( ob);
     return 1;
   }
+
+  return 0;
 }
 
 void lock_door(object  key)
@@ -551,6 +553,8 @@ int lock( string str)
     lock_door( ob);
     return 1;
   }
+
+  return 0;
 }
 
 

--- a/mud/lp-245/obj/living.c
+++ b/mud/lp-245/obj/living.c
@@ -537,6 +537,8 @@ int attack()
     alt_attacker_ob = 0;
     if (attacker_ob)
 	return 1;
+
+    return 0;
 }
 
 object query_attack() {

--- a/mud/lp-245/obj/master.c
+++ b/mud/lp-245/obj/master.c
@@ -1527,6 +1527,8 @@ int valid_snoop (object snoopee, object snooper)
     */
     if (object_name(previous_object()) == get_simul_efun())
         return 1;
+
+    return 0;
 }
 
 

--- a/mud/lp-245/obj/money.c
+++ b/mud/lp-245/obj/money.c
@@ -44,6 +44,8 @@ int id(string str) {
 	return 1;
     if (str == "money")
 	return 1;
+
+  return 0;
 }
 
 void heart_beat() {

--- a/mud/lp-245/obj/simul_efun.c
+++ b/mud/lp-245/obj/simul_efun.c
@@ -201,6 +201,8 @@ varargs mixed snoop(mixed snoopee)
 	    break;
     }
     if (result > 0) return snoopee;
+
+    return 0;
 }
 
 //---------------------------------------------------------------------------

--- a/mud/lp-245/obj/trace.c
+++ b/mud/lp-245/obj/trace.c
@@ -386,7 +386,7 @@ int Goto(string str) {
 /*
  * This will not work because command() only works for command_giver.
  */
-int in(string str) {
+int do_in(string str) {
     object mark, here;
     string path, cmd;
 

--- a/mud/lp-245/obj/trace.c
+++ b/mud/lp-245/obj/trace.c
@@ -383,28 +383,6 @@ int Goto(string str) {
     return 1;
 }
 
-/*
- * This will not work because command() only works for command_giver.
- */
-int do_in(string str) {
-    object mark, here;
-    string path, cmd;
-
-    if (!str)
-	return 0;
-    if (sscanf(str, "%s %s", path, cmd) != 2)
-	return 0;
-    mark = parse_list(path);
-    if (!mark)
-	return 0;
-    here = environment(this_player());
-    move_object(this_player(), mark);
-    command(cmd);
-    move_object(this_player(), here);
-    write("Ok.\n");
-    return 1;
-}
-
 int In(string str) {
     string path, cmd;
     object ob, old_ob;

--- a/mud/lp-245/obj/trace2.c
+++ b/mud/lp-245/obj/trace2.c
@@ -362,28 +362,6 @@ int Goto(string str) {
     return 1;
 }
 
-/*
- * This will not work because command() only works for command_giver.
- */
-int do_in(string str) {
-    object mark, here;
-    string path, cmd;
-
-    if (!str)
-	return 0;
-    if (sscanf(str, "%s %s", path, cmd) != 2)
-	return 0;
-    mark = parse_list(path);
-    if (!mark)
-	return 0;
-    here = environment(this_player());
-    move_object(this_player(), mark);
-    command(cmd);
-    move_object(this_player(), here);
-    write("Ok.\n");
-    return 1;
-}
-
 int In(string str) {
     string path, cmd;
     object ob, old_ob;

--- a/mud/lp-245/obj/trace2.c
+++ b/mud/lp-245/obj/trace2.c
@@ -365,7 +365,7 @@ int Goto(string str) {
 /*
  * This will not work because command() only works for command_giver.
  */
-int in(string str) {
+int do_in(string str) {
     object mark, here;
     string path, cmd;
 

--- a/mud/lp-245/room/death/death.c
+++ b/mud/lp-245/room/death/death.c
@@ -111,4 +111,5 @@ int take_it(string str)
 
 	}
 
+  return 0;
 }

--- a/mud/lp-245/room/narr_alley.c
+++ b/mud/lp-245/room/narr_alley.c
@@ -25,4 +25,6 @@ int go_down() {
 int id(string str) {
     if (str == "well")
 	return 1;
+
+    return 0;
 }


### PR DESCRIPTION
This PR fixes a handful of warnings that occur when running the `mud/lp-245` sample MUD lib with the current driver version. I only went as far as to fix warnings in code that is preloaded at startup. More warnings may exist in parts of the lib that are not listed in `mud/lp-245/room/init_file`.