### PR TITLE
lp-245: add TLS logon port support, cmd.

### DIFF
--- a/mud/lp-245/obj/master.c
+++ b/mud/lp-245/obj/master.c
@@ -54,6 +54,10 @@ static void mudwho_exec(object obfrom, object ob);
 #    define mudwho_exec(a,b)       0
 #endif
 
+#if defined(__TLS__) && defined(TLS_PORT)
+#include "/sys/interactive_info.h"
+#endif
+
 void save_wiz_file(); // forward
 int query_player_level (string what); // forward
 
@@ -712,16 +716,24 @@ object connect ()
 // binding the connection to it. That lfun has to return !=0 to succeed.
 
 {
-    object ob;
-    string ret;
-
-    write("Lars says: Let's get a body for your character ...");
-    ob = clone_object("obj/player");
-    write("\n");
-    if (ret) {
-	write(ret + "\n");
-	return 0;
+    object ob = clone_object("obj/player");
+    if (!ob) {
+        write("Lars says: Couldn't get your body ready ...\n");
+        return 0;
     }
+
+#if defined(__TLS__) && defined(TLS_PORT)
+    // Figure out what port the interactive is connected to.
+    int mud_port = efun::interactive_info(this_interactive(), II_MUD_PORT);
+    // If it's the TLS_PORT, then try to initialize TLS.
+    if (mud_port == TLS_PORT) {
+        // reject connection if TLS is not available
+        if (!tls_available())
+            return 0;
+        tls_init_connection(this_object(), (: $2 && $2->tls_init($1) :), ob);
+    }
+#endif
+
     mudwho_connect(ob);
     return ob;
 }


### PR DESCRIPTION
## Description

This PR updates `obj/master.c` and `obj/player.c` in the `mud/lp-245/` sample lib in order to optionally support a dedicated TLS port. This port will always negotiate TLS and can be used with clients like Blightmud, Mudlet, and Tintin++. Having STARTTLS support on the telnet port is on my radar for a follow-up PR. In the meantime the dedicated TLS port works well with existing MUD clients and I think having an out-of-box example is helpful while I figure out the best way to add STARTTLS to `lp-245` without too much telnet negotiation complexity.

Beyond building LDMud with TLS support and configuring the certificate/key/issuer files the code added in this commit expects a `TLS_PORT` to be defined. I recommend passing this to the LDMud binary at runtime as a command line flag with `-D"TLS_PORT=xxxx"`, matching a port number provided to LD after all other arguments alongside a telnet port choice.

e.g. to have LD run this lib with telnet on port 4242 and TLS on port 4141 use:

```
ldmud -D"TLS_PORT=4141" 4242 4141 ...
```

Users that run the `lp-245` lib without TLS support in-driver, or without the `TLS_PORT` define should observe no noticeable differences with this code in place (or it's a bug I'd like to fix!).

## In-Game `tls` Command
Once connected, a simple `tls` command is added to the set of player commands to display the current connection's TLS status:

```
> tls
You are presently connected via a TLS secured connection.
Protocol: TLSv1.3 Ciphersuite: TLS_AES_256_GCM_SHA384
```
or

```
> tls
You are presently connected via an insecure telnet connection.
```

## Tutorial

I've also been using this branch as part of a [more complete tutorial](https://github.com/cpu/ldmud-tutorial) for setting up a LDMud server with Python + TLS support. I'm not sure if that's something maintainers would be interested in linking to or moving to this repo. Happy to discuss! 