### PR TITLE
docs: remove stale special cmds references.

### DIFF
--- a/doc/concepts/hooks
+++ b/doc/concepts/hooks
@@ -70,8 +70,7 @@ DESCRIPTION
 
         H_MODIFY_COMMAND
           Optional hook to modify commands (both entered or given by a
-          call to command()) before the parser sees them (this includes
-          special commands like 'status').
+          call to command()) before the parser sees them.
 
 
         H_MODIFY_COMMAND_FNAME

--- a/doc/hook/modify_command
+++ b/doc/hook/modify_command
@@ -11,8 +11,7 @@ SYNOPSIS
 
 DESCRIPTION
         Optional hook to modify commands (both entered or given by a
-        call to command()) before the parser sees them (this includes
-        special commands like 'status').
+        call to command()) before the parser sees them.
 
         Hook setting can be any closure, the name of the function to
         call in the object, or a mapping.


### PR DESCRIPTION
Previously the `doc/concepts/hooks` and `doc/hook/modify_command` doc files referenced the `H_MODIFY_COMMAND` hook running before "special commands" were processed. These special commands were removed in 3.5.x in favour of being provided by the lib instead of the driver.

This commit removes special command references to since special commands are no longer a concern.