### PR TITLE
doc: Add coroutine info to driver_info manpage.

### DIFF
--- a/doc/efun/driver_info
+++ b/doc/efun/driver_info
@@ -385,6 +385,9 @@ DESCRIPTION
         <what> == DI_NUM_NAMED_OBJECT_TYPES_TABLE_SLOTS:
           Number of table entries for named object types.
 
+        <what> == DI_NUM_COROUTINES:
+          Number of coroutines.
+
         <what> == DI_NUM_LWOBJECTS:
           Number of lightweight objects.
 
@@ -464,6 +467,9 @@ DESCRIPTION
         <what> == DI_SIZE_LWOBJECTS:
           The size of all lightweight objects (not counting the size
           of the values of their variables).
+
+        <what> == DI_SIZE_COROUTINES
+          The size of all coroutines.
 
 
 


### PR DESCRIPTION
In https://github.com/ldmud/ldmud/commit/1f36a52038c77851c814b239e0a1e1e5d951d64f coroutine statistics were implemented, including adding constants (`DI_NUM_COROUTINES`, & `DI_SIZE_COROUTINES`) to use with `efun::driver_info` to fetch a count of the number of coroutines loaded, and their size in memory. This commit adds a mention of these two `what` values in the man page for the `driver_info` efun.