### PR TITLE
Remove extra paren in references example

### DIFF
--- a/doc/LPC/references
+++ b/doc/LPC/references
@@ -33,7 +33,7 @@ EXAMPLE
             assign(&(a[<0..<1]), ({1,2,3,"sink","x","y","x"}));
             assign(&(a[5][0]), 'w');
             assign(&(a[5][<1]), 'g');
-            printf("%O", a));
+            printf("%O", a);
         }
 
         ({ /* sizeof() == 9 */


### PR DESCRIPTION
Removed an extra closing paren in the example code on the `references` man page.