### PR TITLE
util/erq/erq.c: Fix buffer overrun

### DIFF
--- a/src/util/erq/erq.c
+++ b/src/util/erq/erq.c
@@ -155,7 +155,7 @@ union ticket_u
 {
     struct ticket_s
     {
-        long rnd, seq;
+        int32_t rnd, seq;
     } s;
     char c[1];
 };


### PR DESCRIPTION
When this code was written, a long was 4 bytes (wow!), and random() returned a 4-byte value.  On modern systems, longs are 8 bytes.  The code is still assuming that longs are 4 bytes, and this causes a buffer overrun in ticket generation.

Update ticket_u to store rnd and seq as 4-byte values, and use this to store the bottom half of the value returned from random() (which also returns an 8-byte value these days).

Lightly tested, but I'm not sure how erq worked on 64-bit systems.  Is it being used anywhere on 64-bit systems?