### PR TITLE
Feature/sprintf lpc limits

### DIFF
--- a/doc/efun.de/sprintf.de
+++ b/doc/efun.de/sprintf.de
@@ -56,10 +56,12 @@ BESCHREIBUNG
                      einem Fuellzeichen aufgefuellt. Beginnt n mit einer
                      '0' (etwa "08") so ist das Fuellzeichen '0' sonst
                      ist es per Default ' '. (sogenannte 'Feldbreite')
+                     Bei %O/%Q die maximale Rekursionstiefe.
         .n           Bei Ganzzahlen die Maxanzahl der Stellen, bei Gleit-
                      kommazahlen die Maximalzahl der Nachkommastellen.
                      Bei (einfachen) Strings die Maximallaenge.
-                     Bei %O/%Q die maximale Rekursionstiefe.
+                     Bei %O/%Q die maximale Anzahl an Elementen von Arrays/
+                     Mappings/Structs.
         :n           Ist dasselbe wie n.n - setzt also beide Werte auf
                      dieselbe Zahl.
         'X'          Als Fuellzeichen wird X genutzt. X koennen dabei

--- a/doc/efun.de/sprintf.de
+++ b/doc/efun.de/sprintf.de
@@ -59,6 +59,7 @@ BESCHREIBUNG
         .n           Bei Ganzzahlen die Maxanzahl der Stellen, bei Gleit-
                      kommazahlen die Maximalzahl der Nachkommastellen.
                      Bei (einfachen) Strings die Maximallaenge.
+                     Bei %O/%Q die maximale Rekursionstiefe.
         :n           Ist dasselbe wie n.n - setzt also beide Werte auf
                      dieselbe Zahl.
         'X'          Als Fuellzeichen wird X genutzt. X koennen dabei

--- a/doc/efun/sprintf
+++ b/doc/efun/sprintf
@@ -48,6 +48,7 @@ DESCRIPTION
                 a 0, the argument is printed with leading zeroes.
           "."n  specifies the precision, for simple (not columns or tables)
                 strings specifies the truncation length.
+                For %O/%Q this specifies the maximum recursion depth.
           ":"n  n specifies both the field size _and_ the presision, if n is
                 prepended by a zero then the pad string is set to "0".
           "'X'" the pad string is set to the char(s) between the single
@@ -82,6 +83,8 @@ DESCRIPTION
                 For %O/%Q: compact output.
           "@"   the argument is an array.  the corresponding AFS (minus all
                 "@") is applied to each element of the array.
+          "*"   Can be placed instead of a number, the value is then expected
+                in an additional argument to the function call.
 
         When the formatting of an element results in several output lines
         (column or table mode) and no explicit pad strings has been

--- a/doc/efun/sprintf
+++ b/doc/efun/sprintf
@@ -46,9 +46,11 @@ DESCRIPTION
         Modifiers:
            n    specifies the field size. If the size is prepended with
                 a 0, the argument is printed with leading zeroes.
+                For %O/%Q this specifies the maximum recursion depth.
           "."n  specifies the precision, for simple (not columns or tables)
                 strings specifies the truncation length.
-                For %O/%Q this specifies the maximum recursion depth.
+                For %O/%Q this specifies the maximum number of array/mapping/
+                struct elements to print.
           ":"n  n specifies both the field size _and_ the presision, if n is
                 prepended by a zero then the pad string is set to "0".
           "'X'" the pad string is set to the char(s) between the single

--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -47,10 +47,13 @@
  *   n    specifies the field size, a '*' specifies to use the corresponding
  *        arg as the field size.  If n is prepended with a zero, then the field
  *        is printed with leading zeros.
- *  "."n  precision of n, simple strings truncate after this (if precision is
- *        greater than field size, then field size = precision), tables use
- *        precision to specify the number of columns (if precision not specified
- *        then tables calculate a best fit), all other types ignore this.
+ *  "."n  precision of n
+ *        floats are rounded to this precision
+ *        simple strings truncate after this (if precision is greater than 
+ *         field size, then field size = precision).
+ *        tables use precision to specify the number of columns (if precision
+ *         not specified then tables calculate a best fit).
+ *        with %O/%Q: limit recursion to n levels.
  *  ":"n  n specifies the fs _and_ the precision, if n is prepended by a zero
  *        then it is padded with zeros instead of spaces.
  *  "@"   the argument is an array.  the corresponding format_info (minus the
@@ -264,7 +267,8 @@ struct sprintf_buffer
 struct stsf_locals
 {
     sprintf_buffer_t *spb;  /* Target buffer */
-    int indent;             /* Indentation */
+    int depth;              /* Recursion depth */
+    int maxDepth;           /* Max recursion depth */
     int num_values;         /* Mapping width */
     Bool quote;             /* TRUE: Quote strings */
     Bool compact;           /* TRUE: Compact output */
@@ -325,7 +329,7 @@ static fmt_state_t static_fmt;
 
 static sprintf_buffer_t *svalue_to_string(fmt_state_t *
                                          , svalue_t *, sprintf_buffer_t *
-                                         , int, Bool, Bool, Bool, Bool);
+                                         , int, Bool, Bool, Bool, Bool, int);
 
 /*-------------------------------------------------------------------------*/
 /* static helper functions */
@@ -583,16 +587,16 @@ svalue_to_string_filter(svalue_t *key, svalue_t *data, void *extra)
 {
     int i;
     stsf_locals_t *locals = (stsf_locals_t *)extra;
-    char *delimiter = ":";
+    char *delimiter = ": ";
 
     i = locals->num_values;
     locals->spb =
-      svalue_to_string(locals->st, key, locals->spb, locals->indent, !i, locals->quote, locals->compact, MY_FALSE);
+      svalue_to_string(locals->st, key, locals->spb, locals->depth, !i, locals->quote, locals->compact, MY_FALSE, locals->maxDepth);
     while (--i >= 0)
     {
         stradd(locals->st, &locals->spb, delimiter);
-        locals->spb = svalue_to_string(locals->st, data++, locals->spb, 1, !i, locals->quote, locals->compact, MY_FALSE);
-        delimiter = ";";
+        locals->spb = svalue_to_string(locals->st, data++, locals->spb, locals->depth, !i, locals->quote, locals->compact, MY_TRUE, locals->maxDepth);
+        delimiter = "; ";
     }
 } /* svalue_to_string_filter() */
 
@@ -687,15 +691,17 @@ string_to_string (fmt_state_t *st, string_t* obj, size_t index1, size_t index2, 
 static sprintf_buffer_t *
 svalue_to_string ( fmt_state_t *st
                  , svalue_t *obj, sprintf_buffer_t *str
-                 , int indent, Bool trailing, Bool quoteStrings
-                 , Bool compact, Bool prefixed)
+                 , int depth, Bool trailing, Bool quoteStrings
+                 , Bool compact, Bool prefixed, int maxDepth)
 
-/* Print the value <obj> into the buffer <str> with indentation <indent>.
+/* Print the value <obj> into the buffer <str> with recursion deptth <depth>.
  * If <trailing> is true, add ",\n" after the printed value.
  * If <qoute> is true, special characters in strings are quoted LPC-style.
  * If <compact> is true, a short output format is used.
  * If <prefixed> is true, the caller has printed something ahead of this
  * value, meaning that for the first line no indentation is required.
+ * If <maxDepth> recursions are reached, the content of arrays/mappings/structs
+ * is only printed as "..."
  *
  * Result is the (updated) string buffer.
  * The function calls itself for recursive values.
@@ -704,7 +710,7 @@ svalue_to_string ( fmt_state_t *st
     mp_int i;
 
     if (!compact && !prefixed)
-        add_indent(st, &str, indent);
+        add_indent(st, &str, depth * SPRINTF_LPC_INDENT);
 
     switch (obj->type)
     {
@@ -723,7 +729,10 @@ svalue_to_string ( fmt_state_t *st
                 break;
 
             case LVALUE_PROTECTED:
-                str = svalue_to_string(st, &(obj->u.protected_lvalue->val), str, indent+2, MY_FALSE, quoteStrings, compact, MY_TRUE);
+                if (depth >= maxDepth)
+                    stradd(st, &str, "...");
+                else
+                    str = svalue_to_string(st, &(obj->u.protected_lvalue->val), str, depth+1, MY_FALSE, quoteStrings, compact, MY_TRUE, maxDepth);
                 break;
 
             case LVALUE_PROTECTED_CHAR:
@@ -795,13 +804,20 @@ svalue_to_string ( fmt_state_t *st
                                     numadd(st, &str, size);
                                     stradd(st, &str, " */\n");
                                 }
-                                for (i = r->index1; i < r->index2-1; i++)
-                                    str = svalue_to_string(st, &(vec->u.vec->item[i]), str, indent+2, MY_TRUE, quoteStrings, compact, MY_FALSE);
-                                str = svalue_to_string(st, &(vec->u.vec->item[i]), str, indent+2, MY_FALSE, quoteStrings, compact, MY_FALSE);
-                                if (!compact)
+                                if (maxDepth > 0 && depth >= maxDepth)
                                 {
-                                    stradd(st, &str, "\n");
-                                    add_indent(st, &str, indent);
+                                    stradd(st, &str, "...");
+                                }
+                                else
+                                {
+                                    for (i = r->index1; i < r->index2-1; i++)
+                                        str = svalue_to_string(st, &(vec->u.vec->item[i]), str, depth+1, MY_TRUE, quoteStrings, compact, MY_FALSE, maxDepth);
+                                    str = svalue_to_string(st, &(vec->u.vec->item[i]), str, depth+1, MY_FALSE, quoteStrings, compact, MY_FALSE, maxDepth);
+                                    if (!compact)
+                                    {
+                                        stradd(st, &str, "\n");
+                                        add_indent(st, &str, depth * SPRINTF_LPC_INDENT);
+                                    }
                                 }
                                 stradd(st, &str, "})");
                             }
@@ -824,16 +840,16 @@ svalue_to_string ( fmt_state_t *st
                     }
 
                     default:
-                        stradd(st, &str, "!ERROR: GARBAGE RANGE TYPE (");
-                        numadd(st, &str, vec->type);
-                        stradd(st, &str, ")!");
-                        break;
+                    stradd(st, &str, "!ERROR: GARBAGE RANGE TYPE (");
+                    numadd(st, &str, vec->type);
+                    stradd(st, &str, ")!");
+                    break;
                 }
                 break;
             }
 
             case LVALUE_PROTECTED_MAPENTRY:
-                return svalue_to_string(st, get_rvalue(obj, NULL), str, indent, trailing, quoteStrings, compact, prefixed);
+            return svalue_to_string(st, get_rvalue(obj, NULL), str, depth, trailing, quoteStrings, compact, prefixed, maxDepth);
 
             case LVALUE_PROTECTED_MAP_RANGE:
             {
@@ -842,6 +858,10 @@ svalue_to_string ( fmt_state_t *st
                 if (!size)
                 {
                     stradd(st, &str, compact ? "({})" : "({ })");
+                }
+                else if (maxDepth > 0 && depth >= maxDepth)
+                {
+                    stradd(st, &str, "...");
                 }
                 else
                 {
@@ -876,24 +896,24 @@ svalue_to_string ( fmt_state_t *st
                             for (i = r->index1; i < r->index2-1; i++)
                             {
                                 if (!compact)
-                                    add_indent(st, &str, indent);
+                                    add_indent(st, &str, depth * SPRINTF_LPC_INDENT);
                                 stradd(st, &str, compact ? "0," : "0,\n");
                             }
                             if (!compact)
-                                add_indent(st, &str, indent);
+                                add_indent(st, &str, depth * SPRINTF_LPC_INDENT);
                             stradd(st, &str, "0");
                         }
                         else
                         {
                             for (i = r->index1; i < r->index2-1; i++)
-                                str = svalue_to_string(st, item + i, str, indent+2, MY_TRUE, quoteStrings, compact, MY_FALSE);
-                            str = svalue_to_string(st, item + i, str, indent+2, MY_FALSE, quoteStrings, compact, MY_FALSE);
+                                str = svalue_to_string(st, item + i, str, depth+1, MY_TRUE, quoteStrings, compact, MY_FALSE, maxDepth);
+                            str = svalue_to_string(st, item + i, str, depth+1, MY_FALSE, quoteStrings, compact, MY_FALSE, maxDepth);
                         }
 
                         if (!compact)
                         {
                             stradd(st, &str, "\n");
-                            add_indent(st, &str, indent);
+                            add_indent(st, &str, depth * SPRINTF_LPC_INDENT);
                         }
                         stradd(st, &str, "})");
                     }
@@ -917,22 +937,22 @@ svalue_to_string ( fmt_state_t *st
         break;
 
     case T_FLOAT:
-      {
-        char s[200]; /* TODO: Might be too small */
-        double d;
+        {
+            char s[200]; /* TODO: Might be too small */
+            double d;
 
-        d = READ_DOUBLE(obj);
+            d = READ_DOUBLE(obj);
 #ifdef HAVE_TRUNC
-        if (trunc(d) == d)
+            if (trunc(d) == d)
 #else
-        if ((d >= 0.0 ? floor(d) : ceil(d)) == d)
+                if ((d >= 0.0 ? floor(d) : ceil(d)) == d)
 #endif
-            sprintf(s, "%g.0", d );
-        else
-            sprintf(s, "%g", d );
-        stradd(st, &str, s);
-        break;
-      }
+                    sprintf(s, "%g.0", d );
+                else
+                    sprintf(s, "%g", d );
+            stradd(st, &str, s);
+            break;
+        }
 
     case T_STRING:
     case T_BYTES:
@@ -940,28 +960,88 @@ svalue_to_string ( fmt_state_t *st
         break;
 
     case T_QUOTED_ARRAY:
-      {
-        i = obj->x.quotes;
-        do {
-            stradd(st, &str, "\'");
-        } while (--i);
-      }
-      /* FALLTHROUGH */
+        {
+            i = obj->x.quotes;
+            do {
+                stradd(st, &str, "\'");
+            } while (--i);
+        }
+        /* FALLTHROUGH */
 
     case T_POINTER:
-      {
-        size_t size;
+        {
+            size_t size;
 
-        size = VEC_SIZE(obj->u.vec);
-        if (!size)
-        {
-            stradd(st, &str, compact ? "({})" : "({ })");
+            size = VEC_SIZE(obj->u.vec);
+            if (!size)
+            {
+                stradd(st, &str, compact ? "({})" : "({ })");
+            }
+            else
+            {
+                struct pointer_record *prec;
+
+                prec = find_add_pointer(st->ptable, obj->u.vec, MY_TRUE);
+                if (!prec->id_number)
+                {
+                    /* New array */
+                    prec->id_number = st->pointer_id++;
+
+                    if (compact)
+                    {
+                        stradd(st, &str, "({#");
+                        numadd(st, &str, prec->id_number);
+                        stradd(st, &str, " ");
+                    }
+                    else
+                    {
+                        stradd(st, &str, "({ /* #");
+                        numadd(st, &str, prec->id_number);
+                        stradd(st, &str, ", size: ");
+                        numadd(st, &str, size);
+                        stradd(st, &str, " */");
+                    }
+                    if (maxDepth > 0 && depth >= maxDepth)
+                    {
+                        stradd(st, &str, "...");
+                    }
+                    else
+                    {
+                        if (!compact)
+                            stradd(st, &str, "\n");
+                        for (i = 0; (size_t)i < size-1; i++)
+                        {
+                            str = svalue_to_string(st, &(obj->u.vec->item[i]), str, depth+1, MY_TRUE, quoteStrings, compact, MY_FALSE, maxDepth);
+                        }
+                        str = svalue_to_string(st, &(obj->u.vec->item[i]), str, depth+1, MY_FALSE, quoteStrings, compact, MY_FALSE, maxDepth);
+                        if (!compact)
+                        {
+                            stradd(st, &str, "\n");
+                            add_indent(st, &str, depth * SPRINTF_LPC_INDENT);
+                        }
+                    }
+                    stradd(st, &str, "})");
+                }
+                else
+                {
+                    /* Recursion! */
+                    stradd(st, &str, compact ? "({#" : "({ #");
+                    numadd(st, &str, prec->id_number);
+                    stradd(st, &str, compact ? "})" : " })");
+                }
+            }
+            break;
         }
-        else
+
+    case T_STRUCT:
         {
+            struct_t *strct = obj->u.strct;
+            size_t size;
             struct pointer_record *prec;
 
-            prec = find_add_pointer(st->ptable, obj->u.vec, MY_TRUE);
+            size = struct_size(strct);
+
+            prec = find_add_pointer(st->ptable, strct, MY_TRUE);
             if (!prec->id_number)
             {
                 /* New array */
@@ -969,202 +1049,186 @@ svalue_to_string ( fmt_state_t *st
 
                 if (compact)
                 {
-                    stradd(st, &str, "({#");
+                    stradd(st, &str, "(<'");
+                    stradd(st, &str, get_txt(struct_unique_name(strct)));
+                    stradd(st, &str, "'#");
                     numadd(st, &str, prec->id_number);
                     stradd(st, &str, " ");
                 }
                 else
                 {
-                    stradd(st, &str, "({ /* #");
+                    stradd(st, &str, "(<'");
+                    stradd(st, &str, get_txt(struct_unique_name(strct)));
+                    stradd(st, &str, "' /* #");
                     numadd(st, &str, prec->id_number);
                     stradd(st, &str, ", size: ");
                     numadd(st, &str, size);
-                    stradd(st, &str, " */\n");
+                    stradd(st, &str, " */");
                 }
-                for (i = 0; (size_t)i < size-1; i++)
+                if (maxDepth > 0 && depth >= maxDepth)
                 {
-                    str = svalue_to_string(st, &(obj->u.vec->item[i]), str, indent+2, MY_TRUE, quoteStrings, compact, MY_FALSE);
+                    stradd(st, &str, "...");
                 }
-                str = svalue_to_string(st, &(obj->u.vec->item[i]), str, indent+2, MY_FALSE, quoteStrings, compact, MY_FALSE);
-                if (!compact)
-                {
-                    stradd(st, &str, "\n");
-                    add_indent(st, &str, indent);
-                }
-                stradd(st, &str, "})");
-            }
-            else
-            {
-                /* Recursion! */
-                stradd(st, &str, compact ? "({#" : "({ #");
-                numadd(st, &str, prec->id_number);
-                stradd(st, &str, compact ? "})" : " })");
-            }
-        }
-        break;
-      }
-
-    case T_STRUCT:
-      {
-        struct_t *strct = obj->u.strct;
-        size_t size;
-        struct pointer_record *prec;
-
-        size = struct_size(strct);
-
-        prec = find_add_pointer(st->ptable, strct, MY_TRUE);
-        if (!prec->id_number)
-        {
-            /* New array */
-            prec->id_number = st->pointer_id++;
-            
-            if (compact)
-            {
-                stradd(st, &str, "(<'");
-                stradd(st, &str, get_txt(struct_unique_name(strct)));
-                stradd(st, &str, "'#");
-                numadd(st, &str, prec->id_number);
-                stradd(st, &str, " ");
-            }
-            else
-            {
-                stradd(st, &str, "(<'");
-                stradd(st, &str, get_txt(struct_unique_name(strct)));
-                stradd(st, &str, "' /* #");
-                numadd(st, &str, prec->id_number);
-                stradd(st, &str, ", size: ");
-                numadd(st, &str, size);
-                stradd(st, &str, " */");
-            }
-            if (size)
-            {
-                if (!compact)
-                    stradd(st, &str, "\n");
-                for (i = 0; (size_t)i < size-1; i++)
+                else if (size)
                 {
                     if (!compact)
+                        stradd(st, &str, "\n");
+                    for (i = 0; (size_t)i < size-1; i++)
                     {
-                        add_indent(st, &str, indent+2);
+                        if (!compact)
+                        {
+                            add_indent(st, &str, (depth+1) * SPRINTF_LPC_INDENT);
+                            stradd(st, &str, "/* ");
+                            stradd(st, &str, get_txt(strct->type->member[i].name));
+                            stradd(st, &str, ": */ ");
+                        }
+                        str = svalue_to_string(st, &(strct->member[i]), str, depth+1, MY_TRUE, quoteStrings, compact, !compact, maxDepth);
+                    }
+                    if (!compact)
+                    {
+                        add_indent(st, &str, (depth+1) * SPRINTF_LPC_INDENT);
                         stradd(st, &str, "/* ");
                         stradd(st, &str, get_txt(strct->type->member[i].name));
                         stradd(st, &str, ": */ ");
                     }
-                    str = svalue_to_string(st, &(strct->member[i]), str, indent+2, MY_TRUE, quoteStrings, compact, !compact);
+                    str = svalue_to_string(st, &(strct->member[i]), str, depth+1, MY_FALSE, quoteStrings, compact, !compact, maxDepth);
+                    if (!compact)
+                    {
+                        stradd(st, &str, "\n");
+                        add_indent(st, &str, depth * SPRINTF_LPC_INDENT);
+                    }
                 }
-                if (!compact)
-                {
-                    add_indent(st, &str, indent+2);
-                    stradd(st, &str, "/* ");
-                    stradd(st, &str, get_txt(strct->type->member[i].name));
-                    stradd(st, &str, ": */ ");
-                }
-                str = svalue_to_string(st, &(strct->member[i]), str, indent+2, MY_FALSE, quoteStrings, compact, !compact);
-                if (!compact)
-                {
-                    stradd(st, &str, "\n");
-                    add_indent(st, &str, indent);
-                }
-            }
-            stradd(st, &str, ">)");
-        }
-        else
-        {
-            /* Recursion! */
-            stradd(st, &str, compact ? "(<#" : "(< #");
-            numadd(st, &str, prec->id_number);
-            stradd(st, &str, compact ? ">)" : " >)");
-        }
-        break;
-      }
-
-    case T_MAPPING:
-      {
-        struct stsf_locals locals;
-        struct pointer_record *prec;
-
-        prec = find_add_pointer(st->ptable, obj->u.map, MY_TRUE);
-        if (!prec->id_number)
-        {
-            /* New mapping */
-            prec->id_number = st->pointer_id++;
-
-            stradd(st, &str, compact ? "([#" : "([ /* #");
-            numadd(st, &str, prec->id_number);
-            stradd(st, &str, compact ? " " : " */\n");
-
-            locals.spb = str;
-            locals.indent = indent + 2;
-            locals.num_values = obj->u.map->num_values;
-            locals.st = st;
-            locals.quote = quoteStrings;
-            locals.compact = compact;
-            walk_mapping(obj->u.map, svalue_to_string_filter, &locals);
-            str = locals.spb;
-            if (!compact)
-            {
-                /* Remove the ',' from the trailing ',\n', if any */
-                if (BUF_TEXT(str)[str->offset - 1] == '\n'
-                 && BUF_TEXT(str)[str->offset - 2] == ','
-                   )
-                {
-                    BUF_TEXT(str)[str->offset - 2] = '\n';
-                    str->offset--;
-                }
-                add_indent(st, &str, indent);
+                stradd(st, &str, ">)");
             }
             else
             {
-                /* Remove the trailing, if any */
-                if (BUF_TEXT(str)[str->offset - 1] == ',')
-                    str->offset--;
+                /* Recursion! */
+                stradd(st, &str, compact ? "(<#" : "(< #");
+                numadd(st, &str, prec->id_number);
+                stradd(st, &str, compact ? ">)" : " >)");
             }
-            stradd(st, &str, "])");
-        }
-        else
-        {
-            /* Recursion! */
-            stradd(st, &str, compact ? "([#" : "([ #");
-            numadd(st, &str, prec->id_number);
-            stradd(st, &str, compact ? "])" : " ])");
-        }
-        break;
-      }
-
-    case T_OBJECT:
-      {
-        svalue_t *temp;
-
-        if (obj->u.ob->flags & O_DESTRUCTED)
-        {
-            /* *obj might be a mapping key, thus we mustn't change it. */
-            stradd(st, &str,"0");
             break;
         }
-        if (!compat_mode)
-            stradd(st, &str, "/");
-        stradd(st, &str, get_txt(obj->u.ob->name));
-        if (!compact)
+
+    case T_MAPPING:
         {
-            push_ref_object(inter_sp, obj->u.ob, "sprintf");
-            temp = apply_master(STR_PRINTF_OBJ_NAME, 1);
-            if (temp && (temp->type == T_STRING)) {
-                stradd(st, &str, " (\"");
-                stradd(st, &str, get_txt(temp->u.str));
-                stradd(st, &str, "\")");
+            size_t size;
+
+            size = MAP_SIZE(obj->u.map);
+            if (!size)
+            {
+                stradd(st, &str, compact ? "([])" : "([ ])");
             }
+            else
+            {
+                struct stsf_locals locals;
+                struct pointer_record *prec;
+
+                prec = find_add_pointer(st->ptable, obj->u.map, MY_TRUE);
+                if (!prec->id_number)
+                {
+                    /* New mapping */
+                    prec->id_number = st->pointer_id++;
+
+                    if (compact)
+                    {
+                        stradd(st, &str, "([#");
+                        numadd(st, &str, prec->id_number);
+                        stradd(st, &str, " ");
+                    }
+                    else
+                    {
+                        stradd(st, &str, "([ /* #");
+                        numadd(st, &str, prec->id_number);
+                        stradd(st, &str, ", size: ");
+                        numadd(st, &str, size);
+                        stradd(st, &str, " */");
+                    }
+
+                    if (maxDepth > 0 && depth >= maxDepth)
+                    {
+                        stradd(st, &str, "...");
+                    }
+                    else
+                    {
+                        if (!compact)
+                            stradd(st, &str, "\n");
+                        locals.spb = str;
+                        locals.depth = depth+1;
+                        locals.maxDepth = maxDepth;
+                        locals.num_values = obj->u.map->num_values;
+                        locals.st = st;
+                        locals.quote = quoteStrings;
+                        locals.compact = compact;
+                        walk_mapping(obj->u.map, svalue_to_string_filter, &locals);
+                        str = locals.spb;
+                        if (!compact)
+                        {
+                            /* Remove the ',' from the trailing ',\n', if any */
+                            if (BUF_TEXT(str)[str->offset - 1] == '\n'
+                                    && BUF_TEXT(str)[str->offset - 2] == ','
+                               )
+                            {
+                                BUF_TEXT(str)[str->offset - 2] = '\n';
+                                str->offset--;
+                            }
+                            add_indent(st, &str, depth * SPRINTF_LPC_INDENT);
+                        }
+                        else
+                        {
+                            /* Remove the trailing, if any */
+                            if (BUF_TEXT(str)[str->offset - 1] == ',')
+                                str->offset--;
+                        }
+                    }
+                    stradd(st, &str, "])");
+                }
+                else
+                {
+                    /* Recursion! */
+                    stradd(st, &str, compact ? "([#" : "([ #");
+                    numadd(st, &str, prec->id_number);
+                    stradd(st, &str, compact ? "])" : " ])");
+                }
+            }
+            break;
         }
-        break;
-      }
+
+    case T_OBJECT:
+        {
+            svalue_t *temp;
+
+            if (obj->u.ob->flags & O_DESTRUCTED)
+            {
+                /* *obj might be a mapping key, thus we mustn't change it. */
+                stradd(st, &str,"0");
+                break;
+            }
+            if (!compat_mode)
+                stradd(st, &str, "/");
+            stradd(st, &str, get_txt(obj->u.ob->name));
+            if (!compact)
+            {
+                push_ref_object(inter_sp, obj->u.ob, "sprintf");
+                temp = apply_master(STR_PRINTF_OBJ_NAME, 1);
+                if (temp && (temp->type == T_STRING)) {
+                    stradd(st, &str, " (\"");
+                    stradd(st, &str, get_txt(temp->u.str));
+                    stradd(st, &str, "\")");
+                }
+            }
+            break;
+        }
 
     case T_LWOBJECT:
-      {
-        stradd(st, &str, "(");
-        if (!compat_mode)
-            stradd(st, &str, "/");
-        stradd(st, &str, get_txt(obj->u.lwob->prog->name));
-        stradd(st, &str, ")");
-        break;
-      }
+        {
+            stradd(st, &str, "(");
+            if (!compat_mode)
+                stradd(st, &str, "/");
+            stradd(st, &str, get_txt(obj->u.lwob->prog->name));
+            stradd(st, &str, ")");
+            break;
+        }
 
     case T_SYMBOL:
         i = obj->x.quotes;
@@ -1175,46 +1239,46 @@ svalue_to_string ( fmt_state_t *st
         break;
 
     case T_CLOSURE:
-      {
-        string_t * rc;
+        {
+            string_t * rc;
 
-        rc = closure_to_string(obj, compact);
-        stradd(st, &str, get_txt(rc));
-        free_mstring(rc);
+            rc = closure_to_string(obj, compact);
+            stradd(st, &str, get_txt(rc));
+            free_mstring(rc);
 
-        break;
-    } /* case T_CLOSURE */
+            break;
+        } /* case T_CLOSURE */
 
     case T_COROUTINE:
-      {
-        string_t *rc = coroutine_to_string(obj->u.coroutine);
-        stradd(st, &str, get_txt(rc));
-        free_mstring(rc);
+        {
+            string_t *rc = coroutine_to_string(obj->u.coroutine);
+            stradd(st, &str, get_txt(rc));
+            free_mstring(rc);
 
-        break;
-      }
+            break;
+        }
 
-  default:
-      stradd(st, &str, "!ERROR: GARBAGE SVALUE (");
-      numadd(st, &str, obj->type);
-      stradd(st, &str, ")!");
-  } /* end of switch (obj->type) */
+    default:
+        stradd(st, &str, "!ERROR: GARBAGE SVALUE (");
+        numadd(st, &str, obj->type);
+        stradd(st, &str, ")!");
+    } /* end of switch (obj->type) */
 
-  if (trailing)
-      stradd(st, &str, compact ? "," : ",\n");
+    if (trailing)
+        stradd(st, &str, compact ? "," : ",\n");
 
-  return str;
+    return str;
 } /* svalue_to_string() */
 
 /*-------------------------------------------------------------------------*/
 static void
 add_justified ( fmt_state_t *st
-              , const char *str, size_t len, int fs
-              )
+        , const char *str, size_t len, int fs
+        )
 
-/* Justify string <str> (length <len>) within the fieldsize <fs>.
- * After that, add it to the global buff[].
- */
+    /* Justify string <str> (length <len>) within the fieldsize <fs>.
+     * After that, add it to the global buff[].
+     */
 
 {
     size_t sppos;
@@ -1279,7 +1343,7 @@ add_justified ( fmt_state_t *st
         min_spaces = num_spaces;
     else
         min_spaces = num_spaces / (num_words-1);
-        /* min_spaces * (num_words-1) <= num_spaces < min_spaces * num_words */
+    /* min_spaces * (num_words-1) <= num_spaces < min_spaces * num_words */
 
     /* Loop again over the data, now adding spaces as we go. */
 
@@ -1324,12 +1388,12 @@ add_justified ( fmt_state_t *st
 /*-------------------------------------------------------------------------*/
 static void
 add_aligned ( fmt_state_t *st
-            , const char *str, size_t size, const char *pad, size_t padlen, int fs
-            , format_info finfo)
+        , const char *str, size_t size, const char *pad, size_t padlen, int fs
+        , format_info finfo)
 
-/* Align string <str> (length <len>) within the fieldsize <fs> according
- * to the <finfo>. After that, add it to the global buff[].
- */
+    /* Align string <str> (length <len>) within the fieldsize <fs> according
+     * to the <finfo>. After that, add it to the global buff[].
+     */
 
 {
     size_t sppos;
@@ -1349,47 +1413,47 @@ add_aligned ( fmt_state_t *st
 
     switch(finfo & INFO_A)
     {
-    case INFO_A_JUSTIFY:
-    case INFO_A_LEFT:
-        /* Also called for the last line of a justified block */
-        ADD_STRN(st, str, size);
-        if (is_space_pad)
-            sppos = st->bpos;
-        ADD_PADDING(st, pad, padlen, fs - len);
-        if (is_space_pad)
-            st->sppos = sppos;
-        break;
-
-    case INFO_A_CENTRE:
-        if (finfo & INFO_PS_ZERO)
-        {
-            ADD_PADDING(st, "0", 1, (fs - len + 1) >> 1);
-        }
-        else
-        {
-            ADD_PADDING(st, pad, padlen, (fs - len + 1) >> 1);
-        }
-        ADD_STRN(st, str, size);
-        if (is_space_pad)
-            sppos = st->bpos;
-        ADD_PADDING(st, pad, padlen, (fs - len) >> 1);
-        if (is_space_pad)
-            st->sppos = sppos;
-        break;
-
-    default:
-      { /* std (s)printf defaults to right alignment.
-         */
-        if (finfo & INFO_PS_ZERO)
-        {
-            ADD_PADDING(st, "0", 0, fs - len);
-        }
-        else
-        {
+        case INFO_A_JUSTIFY:
+        case INFO_A_LEFT:
+            /* Also called for the last line of a justified block */
+            ADD_STRN(st, str, size);
+            if (is_space_pad)
+                sppos = st->bpos;
             ADD_PADDING(st, pad, padlen, fs - len);
-        }
-        ADD_STRN(st, str, size);
-      }
+            if (is_space_pad)
+                st->sppos = sppos;
+            break;
+
+        case INFO_A_CENTRE:
+            if (finfo & INFO_PS_ZERO)
+            {
+                ADD_PADDING(st, "0", 1, (fs - len + 1) >> 1);
+            }
+            else
+            {
+                ADD_PADDING(st, pad, padlen, (fs - len + 1) >> 1);
+            }
+            ADD_STRN(st, str, size);
+            if (is_space_pad)
+                sppos = st->bpos;
+            ADD_PADDING(st, pad, padlen, (fs - len) >> 1);
+            if (is_space_pad)
+                st->sppos = sppos;
+            break;
+
+        default:
+            { /* std (s)printf defaults to right alignment.
+               */
+                if (finfo & INFO_PS_ZERO)
+                {
+                    ADD_PADDING(st, "0", 0, fs - len);
+                }
+                else
+                {
+                    ADD_PADDING(st, pad, padlen, fs - len);
+                }
+                ADD_STRN(st, str, size);
+            }
     }
 } /* add_aligned() */
 
@@ -1397,12 +1461,12 @@ add_aligned ( fmt_state_t *st
 static int
 add_column (fmt_state_t *st, cst **column)
 
-/* Add the the next line from <column> to the buffer buff[].
- * Result 0: column not finished (more lines/data pending)
- *        1: column completed and removed from the list
- *        2: column completed with terminating \n, column removed from
- *           the list.
- */
+    /* Add the the next line from <column> to the buffer buff[].
+     * Result 0: column not finished (more lines/data pending)
+     *        1: column completed and removed from the list
+     *        2: column completed with terminating \n, column removed from
+     *           the list.
+     */
 
 {
 #define COL (*column)
@@ -1500,8 +1564,8 @@ add_column (fmt_state_t *st, cst **column)
      * justified lines ending in NL.
      */
     if ((COL->info & INFO_A) == INFO_A_JUSTIFY
-     && *COL_D && *(COL_D+1)
-     && *p != '\n' && *p != '\r' && *p != '\0'
+            && *COL_D && *(COL_D+1)
+            && *p != '\n' && *p != '\r' && *p != '\0'
        )
     {
         add_justified(st, COL_D, p - COL_D, COL->size);
@@ -1545,9 +1609,9 @@ add_column (fmt_state_t *st, cst **column)
 static Bool
 add_table (fmt_state_t *st, cst **table)
 
-/* Add the next line of <table> to the buffer.
- * Return TRUE if the table was completed and removed from the list.
- */
+    /* Add the next line of <table> to the buffer.
+     * Return TRUE if the table was completed and removed from the list.
+     */
 
 {
     unsigned int done, i, finished = 0;
@@ -1617,18 +1681,18 @@ add_table (fmt_state_t *st, cst **table)
 static string_t *
 string_print_formatted (char *format_str, size_t format_len, int argc, svalue_t *argv)
 
-/* The (s)printf() function: format <format_str> (of size <format_len> bytes)
- * with the given arguments and return a pointer to the result (a string with
- * one reference).
- *
- * If an error occurs and RETURN_ERROR_MESSAGES is defined, an error
- * will return the error string as result; if R_E_M is undefined, an
- * true errorf() is raised.
- */
+    /* The (s)printf() function: format <format_str> (of size <format_len> bytes)
+     * with the given arguments and return a pointer to the result (a string with
+     * one reference).
+     *
+     * If an error occurs and RETURN_ERROR_MESSAGES is defined, an error
+     * will return the error string as result; if R_E_M is undefined, an
+     * true errorf() is raised.
+     */
 
 {
 #ifndef RETURN_ERROR_MESSAGES
-static char buff[BUFF_SIZE];         /* For error messages */
+    static char buff[BUFF_SIZE];         /* For error messages */
 #endif
     string_t     *result;          /* The result string */
     fmt_state_t  *st;              /* The formatting state */
@@ -1649,57 +1713,57 @@ static char buff[BUFF_SIZE];         /* For error messages */
     int           column_stat;     /* Most recent column add status */
 
 #   define GET_NEXT_ARG {\
-        if (++arg >= argc) ERROR(ERR_TO_FEW_ARGS); \
-        carg = (argv+arg);\
-    }
+    if (++arg >= argc) ERROR(ERR_TO_FEW_ARGS); \
+    carg = (argv+arg);\
+}
 
     result = NULL; /* To get rid of a warning */
 
-    if (!static_fmt_used)
+if (!static_fmt_used)
+{
+    st = &static_fmt;
+    static_fmt_used = MY_TRUE;
+}
+else
+xallocate(st, sizeof *st, "sprintf() context");
+
+st->clean.u.str = NULL;
+st->tmp = NULL;
+st->csts = NULL;
+st->ptable = NULL;
+
+vst = st;
+
+if (0 != (err_num = setjmp(((fmt_state_t*)st)->error_jmp)))
+{
+    /* error handling */
+    char *err;
+    cst  *tcst;
+
+    st = (fmt_state_t*)vst;
+
+    if (st->ptable)
+        free_pointer_table(st->ptable);
+
+    /* Get rid of a temp string */
+    if (st->clean.u.str)
+        free_mstring(st->clean.u.str);
+    if (st->tmp)
+        xfree(st->tmp);
+
+    /* Free column and table data */
+    while ( NULL != (tcst = st->csts) )
     {
-        st = &static_fmt;
-        static_fmt_used = MY_TRUE;
+        st->csts = tcst->next;
+        if ((tcst->info & (INFO_COLS|INFO_TABLE)) == INFO_TABLE
+                && tcst->d.tab)
+            xfree(tcst->d.tab);
+        xfree(tcst);
     }
-    else
-        xallocate(st, sizeof *st, "sprintf() context");
 
-    st->clean.u.str = NULL;
-    st->tmp = NULL;
-    st->csts = NULL;
-    st->ptable = NULL;
-
-    vst = st;
-
-    if (0 != (err_num = setjmp(((fmt_state_t*)st)->error_jmp)))
+    /* Select the error string */
+    switch(err_num & ERR_ID_NUMBER)
     {
-        /* error handling */
-        char *err;
-        cst  *tcst;
-
-        st = (fmt_state_t*)vst;
-
-        if (st->ptable)
-            free_pointer_table(st->ptable);
-
-        /* Get rid of a temp string */
-        if (st->clean.u.str)
-            free_mstring(st->clean.u.str);
-        if (st->tmp)
-            xfree(st->tmp);
-
-        /* Free column and table data */
-        while ( NULL != (tcst = st->csts) )
-        {
-            st->csts = tcst->next;
-            if ((tcst->info & (INFO_COLS|INFO_TABLE)) == INFO_TABLE
-             && tcst->d.tab)
-                xfree(tcst->d.tab);
-            xfree(tcst);
-        }
-
-        /* Select the error string */
-        switch(err_num & ERR_ID_NUMBER)
-        {
         default:
 #ifdef DEBUG
             fatal("undefined (s)printf() error 0x%X\n", err_num);
@@ -1707,7 +1771,7 @@ static char buff[BUFF_SIZE];         /* For error messages */
         case ERR_BUFF_OVERFLOW:
             err = "BUFF_SIZE overflowed...";
             break;
-                
+
         case ERR_LOCAL_BUFF_OVERFLOW:
             err = "Local buffer on stack in sprintf() overflowed...";
             break;
@@ -1767,260 +1831,260 @@ static char buff[BUFF_SIZE];         /* For error messages */
         case ERR_INVALID_CHAR:
             err = "Invalid character in string.";
             break;
-        }
-
-        /* Create the error message in buff[] */
-        st->buff[0]='\0';
-        if ((err_num & ERR_ID_NUMBER) != ERR_NOMEM)
-        {
-            int line;
-            string_t *file;
-
-            file = NULL;
-            line = get_line_number_if_any(&file);
-            snprintf(st->buff, sizeof(st->buff), "%s:%d: ", get_txt(file), line);
-
-            if (file)
-                free_mstring(file);
-        }
-
-#ifdef RETURN_ERROR_MESSAGES
-        strncat(st->buff, "(s)printf() error: ", sizeof(st->buff)-strlen(st->buff)-1);
-#else
-        strncat(st->buff, "(s)printf(): ",sizeof(st->buff)-strlen(st->buff)-1);
-#endif
-        snprintf(st->buff + strlen(st->buff), sizeof(st->buff)-strlen(st->buff)
-               , err, EXTRACT_ERR_ARGUMENT(err_num));
-        strncat(st->buff, "\n",sizeof(st->buff)-strlen(st->buff)-1);
-#ifndef RETURN_ERROR_MESSAGES
-        strncpy(buff, st->buff, sizeof(buff)-1); // leave one for \0.
-        buff[sizeof(buff)-1]='\0';  // ensure \0 termination
-        if (st == &static_fmt)
-            static_fmt_used = MY_FALSE;
-        else
-            xfree(st);
-        errorf("%s", buff); /* buff may contain a '%' */
-        /* NOTREACHED */
-#else
-        result = new_mstring(st->buff);
-        if (!result)
-            result = ref_mstring(STR_OUT_OF_MEMORY);
-        xfree(st);
-#endif /* RETURN_ERROR_MESSAGES */
-        return result;
     }
 
-    st = (fmt_state_t*)vst;
-
-    format_char = 0;
-    nelemno = 0;
-    column_stat = 0;
-
-    arg = -1;
-    st->bpos = 0;
-    st->sppos = -1;
-    st->line_start = 0;
-
-    /* Walk through the format string */
-    for (fpos = 0; MY_TRUE; fpos++)
+    /* Create the error message in buff[] */
+    st->buff[0]='\0';
+    if ((err_num & ERR_ID_NUMBER) != ERR_NOMEM)
     {
-        if (fpos == format_len || format_str[fpos] == '\n')
+        int line;
+        string_t *file;
+
+        file = NULL;
+        line = get_line_number_if_any(&file);
+        snprintf(st->buff, sizeof(st->buff), "%s:%d: ", get_txt(file), line);
+
+        if (file)
+            free_mstring(file);
+    }
+
+#ifdef RETURN_ERROR_MESSAGES
+    strncat(st->buff, "(s)printf() error: ", sizeof(st->buff)-strlen(st->buff)-1);
+#else
+    strncat(st->buff, "(s)printf(): ",sizeof(st->buff)-strlen(st->buff)-1);
+#endif
+    snprintf(st->buff + strlen(st->buff), sizeof(st->buff)-strlen(st->buff)
+            , err, EXTRACT_ERR_ARGUMENT(err_num));
+    strncat(st->buff, "\n",sizeof(st->buff)-strlen(st->buff)-1);
+#ifndef RETURN_ERROR_MESSAGES
+    strncpy(buff, st->buff, sizeof(buff)-1); // leave one for \0.
+    buff[sizeof(buff)-1]='\0';  // ensure \0 termination
+    if (st == &static_fmt)
+        static_fmt_used = MY_FALSE;
+    else
+        xfree(st);
+    errorf("%s", buff); /* buff may contain a '%' */
+    /* NOTREACHED */
+#else
+    result = new_mstring(st->buff);
+    if (!result)
+        result = ref_mstring(STR_OUT_OF_MEMORY);
+    xfree(st);
+#endif /* RETURN_ERROR_MESSAGES */
+    return result;
+}
+
+st = (fmt_state_t*)vst;
+
+format_char = 0;
+nelemno = 0;
+column_stat = 0;
+
+arg = -1;
+st->bpos = 0;
+st->sppos = -1;
+st->line_start = 0;
+
+/* Walk through the format string */
+for (fpos = 0; MY_TRUE; fpos++)
+{
+    if (fpos == format_len || format_str[fpos] == '\n')
+    {
+        /* Line- or Format end */
+
+        if (!st->csts)
         {
-            /* Line- or Format end */
+            /* No columns/tables to resolve, but add a second
+             * newline if there is one pending from an added
+             * column
+             */
 
-            if (!st->csts)
-            {
-                /* No columns/tables to resolve, but add a second
-                 * newline if there is one pending from an added
-                 * column
-                 */
-
-                if (column_stat == 2)
-                    ADD_CHAR(st, '\n');
-                column_stat = 0;
-                if (fpos == format_len)
-                    break;
-                ADD_CHAR(st, '\n');
-                st->line_start = st->bpos;
-                continue;
-            }
-
-            column_stat = 0; /* If there was a newline pending, it
-                              * will be implicitly added now.
-                              */
-            ADD_CHAR(st, '\n');
-            st->line_start = st->bpos;
-
-            /* Handle pending columns and tables */
-            while (st->csts)
-            {
-                cst **temp;
-
-                /* Add one line from each column/table */
-                temp = &st->csts;
-                while (*temp)
-                {
-                    p_int i;
-                    if ((*temp)->info & INFO_COLS)
-                    {
-                        if ((*temp)->d.col.str[-1] != '\n')
-                            while ((*temp)->d.col.len > 0 && (*temp)->d.col.str[0] == ' ')
-                            {
-                                (*temp)->d.col.str++;
-                                (*temp)->d.col.len--;
-                            }
-
-                        i = (*temp)->start - get_string_width(st->buff + st->line_start, st->bpos - st->line_start, NULL);
-                        if (i > 0)
-                            ADD_CHARN(st, ' ', i);
-                        column_stat = add_column(st, temp);
-                        if (!column_stat)
-                            temp = &((*temp)->next);
-                    }
-                    else
-                    {
-                        i = (*temp)->start - get_string_width(st->buff + st->line_start, st->bpos - st->line_start, NULL);
-                        if (i > 0)
-                            ADD_CHARN(st, ' ', i);
-                        if (!add_table(st, temp))
-                            temp = &((*temp)->next);
-                    }
-                } /* while (*temp) */
-
-                if (st->csts || fpos != format_len)
-                    ADD_CHAR(st, '\n');
-                st->line_start = st->bpos;
-            } /* while (csts) */
-
-            if (column_stat == 2 && fpos == format_len)
+            if (column_stat == 2)
                 ADD_CHAR(st, '\n');
             column_stat = 0;
-
             if (fpos == format_len)
                 break;
+            ADD_CHAR(st, '\n');
+            st->line_start = st->bpos;
             continue;
-        } /* if newline or formatend */
+        }
 
-        if (format_str[fpos] == '%')
+        column_stat = 0; /* If there was a newline pending, it
+                          * will be implicitly added now.
+                          */
+        ADD_CHAR(st, '\n');
+        st->line_start = st->bpos;
+
+        /* Handle pending columns and tables */
+        while (st->csts)
         {
-            /* Another format entry */
+            cst **temp;
 
-            if (fpos + 1 == format_len || format_str[fpos+1] == '%')
+            /* Add one line from each column/table */
+            temp = &st->csts;
+            while (*temp)
             {
-                ADD_CHAR(st, '%');
-                fpos++;
-                continue;
-            }
-
-            if (format_str[fpos+1] == '^')
-            {
-                ADD_CHAR(st, '%');
-                fpos++;
-                ADD_CHAR(st, '^');
-                continue;
-            }
-
-            GET_NEXT_ARG;
-            fs = 0;
-            pres = 0;
-            pad = " ";
-            padlen = 1;
-            finfo = 0;
-
-            /* Parse the formatting entry */
-            for (fpos++; !(finfo & INFO_T); fpos++)
-            {
-                if (fpos == format_len)
+                p_int i;
+                if ((*temp)->info & INFO_COLS)
                 {
-                    finfo |= INFO_T_ERROR;
-                    break;
+                    if ((*temp)->d.col.str[-1] != '\n')
+                        while ((*temp)->d.col.len > 0 && (*temp)->d.col.str[0] == ' ')
+                        {
+                            (*temp)->d.col.str++;
+                            (*temp)->d.col.len--;
+                        }
+
+                    i = (*temp)->start - get_string_width(st->buff + st->line_start, st->bpos - st->line_start, NULL);
+                    if (i > 0)
+                        ADD_CHARN(st, ' ', i);
+                    column_stat = add_column(st, temp);
+                    if (!column_stat)
+                        temp = &((*temp)->next);
                 }
-                if ((format_str[fpos] >= '0' && format_str[fpos] <= '9')
-                 || (format_str[fpos] == '*'))
+                else
                 {
-                    /* Precision resp. fieldwidth */
-                    if (pres == -1) /* then looking for pres */
+                    i = (*temp)->start - get_string_width(st->buff + st->line_start, st->bpos - st->line_start, NULL);
+                    if (i > 0)
+                        ADD_CHARN(st, ' ', i);
+                    if (!add_table(st, temp))
+                        temp = &((*temp)->next);
+                }
+            } /* while (*temp) */
+
+            if (st->csts || fpos != format_len)
+                ADD_CHAR(st, '\n');
+            st->line_start = st->bpos;
+        } /* while (csts) */
+
+        if (column_stat == 2 && fpos == format_len)
+            ADD_CHAR(st, '\n');
+        column_stat = 0;
+
+        if (fpos == format_len)
+            break;
+        continue;
+    } /* if newline or formatend */
+
+    if (format_str[fpos] == '%')
+    {
+        /* Another format entry */
+
+        if (fpos + 1 == format_len || format_str[fpos+1] == '%')
+        {
+            ADD_CHAR(st, '%');
+            fpos++;
+            continue;
+        }
+
+        if (format_str[fpos+1] == '^')
+        {
+            ADD_CHAR(st, '%');
+            fpos++;
+            ADD_CHAR(st, '^');
+            continue;
+        }
+
+        GET_NEXT_ARG;
+        fs = 0;
+        pres = 0;
+        pad = " ";
+        padlen = 1;
+        finfo = 0;
+
+        /* Parse the formatting entry */
+        for (fpos++; !(finfo & INFO_T); fpos++)
+        {
+            if (fpos == format_len)
+            {
+                finfo |= INFO_T_ERROR;
+                break;
+            }
+            if ((format_str[fpos] >= '0' && format_str[fpos] <= '9')
+                    || (format_str[fpos] == '*'))
+            {
+                /* Precision resp. fieldwidth */
+                if (pres == -1) /* then looking for pres */
+                {
+                    if (format_str[fpos] == '*')
+                    {
+                        /* Get the value from the args */
+                        if (carg->type != T_NUMBER)
+                            ERROR(ERR_INVALID_STAR);
+                        pres = carg->u.number;
+                        GET_NEXT_ARG;
+                        continue;
+                    }
+
+                    /* Parse the number */
+                    pres = format_str[fpos] - '0';
+                    for ( fpos++
+                            ; fpos < format_len && format_str[fpos]>='0' && format_str[fpos]<='9'
+                            ; fpos++)
+                    {
+                        int new_pres = pres*10 + format_str[fpos] - '0';
+
+                        if (new_pres < pres) /* Overflow */
+                            ERROR(ERR_SIZE_OVERFLOW);
+
+                        pres = new_pres;
+                    }
+                }
+                else /* then is fs (and maybe pres) */
+                {
+                    if (format_str[fpos] == '0'
+                            && (   (   fpos+1 < format_len
+                                    && format_str[fpos+1] >= '1'
+                                    && format_str[fpos+1] <= '9')
+                                || format_str[fpos+1] == '*')
+                       )
+                        finfo |= INFO_PS_ZERO;
+                    else
                     {
                         if (format_str[fpos] == '*')
                         {
-                            /* Get the value from the args */
                             if (carg->type != T_NUMBER)
                                 ERROR(ERR_INVALID_STAR);
-                            pres = carg->u.number;
+                            if ((p_int)(fs = carg->u.number) < 0)
+                            {
+                                if (fs == (p_uint)PINT_MIN)
+                                    fs = PINT_MAX;
+                                else
+                                    fs = -fs;
+                                finfo |= INFO_A_LEFT;
+                            }
+
+                            if (pres == -2)
+                                pres = fs; /* colon */
                             GET_NEXT_ARG;
                             continue;
                         }
-
-                        /* Parse the number */
-                        pres = format_str[fpos] - '0';
-                        for ( fpos++
-                            ; fpos < format_len && format_str[fpos]>='0' && format_str[fpos]<='9'
-                            ; fpos++)
-                        {
-                            int new_pres = pres*10 + format_str[fpos] - '0';
-
-                            if (new_pres < pres) /* Overflow */
-                                ERROR(ERR_SIZE_OVERFLOW);
-
-                            pres = new_pres;
-                        }
+                        fs = format_str[fpos] - '0';
                     }
-                    else /* then is fs (and maybe pres) */
-                    {
-                        if (format_str[fpos] == '0'
-                         && (   (   fpos+1 < format_len
-                                 && format_str[fpos+1] >= '1'
-                                 && format_str[fpos+1] <= '9')
-                             || format_str[fpos+1] == '*')
-                           )
-                            finfo |= INFO_PS_ZERO;
-                        else
-                        {
-                            if (format_str[fpos] == '*')
-                            {
-                                if (carg->type != T_NUMBER)
-                                    ERROR(ERR_INVALID_STAR);
-                                if ((p_int)(fs = carg->u.number) < 0)
-                                {
-                                    if (fs == (p_uint)PINT_MIN)
-                                        fs = PINT_MAX;
-                                    else
-                                        fs = -fs;
-                                    finfo |= INFO_A_LEFT;
-                                }
 
-                                if (pres == -2)
-                                    pres = fs; /* colon */
-                                GET_NEXT_ARG;
-                                continue;
-                            }
-                            fs = format_str[fpos] - '0';
-                        }
-
-                        for ( fpos++
+                    for ( fpos++
                             ; fpos < format_len && format_str[fpos] >= '0' && format_str[fpos] <= '9'
                             ; fpos++)
-                        {
-                            int new_fs = fs*10 + format_str[fpos] - '0';
+                    {
+                        int new_fs = fs*10 + format_str[fpos] - '0';
 
-                            if (new_fs < fs) /* Overflow */
-                                ERROR(ERR_SIZE_OVERFLOW);
+                        if (new_fs < fs) /* Overflow */
+                            ERROR(ERR_SIZE_OVERFLOW);
 
-                            fs = new_fs;
-                        }
-
-                        if (pres == -2) /* colon */
-                            pres = fs;
+                        fs = new_fs;
                     }
 
-                    fpos--; /* bout to get incremented */
-                    continue;
-                } /* if (precision/alignment field) */
+                    if (pres == -2) /* colon */
+                        pres = fs;
+                }
 
-                /* fpos now points to format type */
+                fpos--; /* bout to get incremented */
+                continue;
+            } /* if (precision/alignment field) */
 
-                switch (format_str[fpos])
-                {
+            /* fpos now points to format type */
+
+            switch (format_str[fpos])
+            {
                 case ' ': finfo |= INFO_PP_SPACE; break;
                 case '+': finfo |= INFO_PP_PLUS; break;
                 case '-': finfo |= INFO_A_LEFT; break;
@@ -2043,607 +2107,608 @@ static char buff[BUFF_SIZE];         /* For error messages */
                 case 'B':
                 case 'x':
                 case 'X':
-                    format_char = format_str[fpos];
-                    finfo |= INFO_T_INT;
-                    break;
+                          format_char = format_str[fpos];
+                          finfo |= INFO_T_INT;
+                          break;
                 case 'f':
                 case 'F':
                 case 'g':
                 case 'G':
                 case 'e':
                 case 'E':
-                    format_char = format_str[fpos];
-                    finfo |= INFO_T_FLOAT;
-                    break;
+                          format_char = format_str[fpos];
+                          finfo |= INFO_T_FLOAT;
+                          break;
                 case '\'':
-                    fpos++;
-                    pad = &(format_str[fpos]);
-                    finfo |= INFO_PS_KEEP;
-                    while (1)
-                    {
-                        if (fpos == format_len)
-                            ERROR(ERR_UNEXPECTED_EOS);
+                          fpos++;
+                          pad = &(format_str[fpos]);
+                          finfo |= INFO_PS_KEEP;
+                          while (1)
+                          {
+                              if (fpos == format_len)
+                                  ERROR(ERR_UNEXPECTED_EOS);
 
-                        if (format_str[fpos] == '\\')
-                        {
-                            if (fpos+1 == format_len)
-                                ERROR(ERR_UNEXPECTED_EOS);
-                            fpos += 2;
-                            continue;
-                        }
+                              if (format_str[fpos] == '\\')
+                              {
+                                  if (fpos+1 == format_len)
+                                      ERROR(ERR_UNEXPECTED_EOS);
+                                  fpos += 2;
+                                  continue;
+                              }
 
-                        if (format_str[fpos] == '\'')
-                        {
-                            padlen = format_str + fpos - pad;
-                            if (padlen == 0)
-                                ERROR(ERR_NULL_PS);
-                            break;
-                        }
-                        fpos++;
-                    }
-                    break;
+                              if (format_str[fpos] == '\'')
+                              {
+                                  padlen = format_str + fpos - pad;
+                                  if (padlen == 0)
+                                      ERROR(ERR_NULL_PS);
+                                  break;
+                              }
+                              fpos++;
+                          }
+                          break;
                 default:
-                    finfo |= INFO_T_ERROR;
-                    break;
-                }
-            } /* for(format parsing) */
-
-            if (pres < 0)
-                ERROR(ERR_PREC_EXPECTED);
-
-            /* Now handle the different arg types...
-             */
-            if (finfo & INFO_ARRAY)
-            {
-                if (carg->type != T_POINTER)
-                    ERROR(ERR_ARRAY_EXPECTED);
-                if (carg->u.vec == &null_vector)
-                {
-                    fpos--; /* 'bout to get incremented */
-                    continue;
-                }
-                carg = (argv+arg)->u.vec->item;
-                nelemno = 1; /* next element number */
+                          finfo |= INFO_T_ERROR;
+                          break;
             }
+        } /* for(format parsing) */
 
-            while(1)
+        if (pres < 0)
+            ERROR(ERR_PREC_EXPECTED);
+
+        /* Now handle the different arg types...
+         */
+        if (finfo & INFO_ARRAY)
+        {
+            if (carg->type != T_POINTER)
+                ERROR(ERR_ARRAY_EXPECTED);
+            if (carg->u.vec == &null_vector)
             {
-                switch(finfo & INFO_T)
-                {
+                fpos--; /* 'bout to get incremented */
+                continue;
+            }
+            carg = (argv+arg)->u.vec->item;
+            nelemno = 1; /* next element number */
+        }
+
+        while(1)
+        {
+            switch(finfo & INFO_T)
+            {
                 case INFO_T_ERROR:
                     ERROR(ERR_INVALID_FORMAT_STR);
 
                 case INFO_T_NULL:
-                  {
-                    /* never reached... */
-                    fprintf(stderr, "%s: (s)printf: INFO_T_NULL.... found.\n"
-                                  , current_object.type == T_OBJECT   ? get_txt(current_object.u.ob->name)
-                                  : current_object.type == T_LWOBJECT ? get_txt(current_object.u.lwob->prog->name)
-                                  : "<unknown object>");
-                    ADD_CHAR(st, '%');
-                    break;
-                  }
+                    {
+                        /* never reached... */
+                        fprintf(stderr, "%s: (s)printf: INFO_T_NULL.... found.\n"
+                                , current_object.type == T_OBJECT   ? get_txt(current_object.u.ob->name)
+                                : current_object.type == T_LWOBJECT ? get_txt(current_object.u.lwob->prog->name)
+                                : "<unknown object>");
+                        ADD_CHAR(st, '%');
+                        break;
+                    }
 
                 case INFO_T_LPC:
                 case INFO_T_QLPC:
-                  {
-                    sprintf_buffer_t *b;
+                    {
+                        sprintf_buffer_t *b;
 #                   define CLEANSIZ 0x200
 
-                    if (st->clean.u.str)
-                        free_mstring(st->clean.u.str);
-                    st->clean.u.str = NULL;
-                    if (st->tmp)
-                        xfree(st->tmp);
+                        if (st->clean.u.str)
+                            free_mstring(st->clean.u.str);
+                        st->clean.u.str = NULL;
+                        if (st->tmp)
+                            xfree(st->tmp);
 
-                    st->tmp = xalloc(CLEANSIZ);
-                    if (!st->tmp)
-                        ERROR(ERR_NOMEM);
-                    st->tmp[0] = '\0';
+                        st->tmp = xalloc(CLEANSIZ);
+                        if (!st->tmp)
+                            ERROR(ERR_NOMEM);
+                        st->tmp[0] = '\0';
 
-                    st->ptable = new_pointer_table();
-                    if (!st->ptable)
-                        ERROR(ERR_NOMEM);
-                    st->pointer_id = 1;
+                        st->ptable = new_pointer_table();
+                        if (!st->ptable)
+                            ERROR(ERR_NOMEM);
+                        st->pointer_id = 1;
 
-                    b = (sprintf_buffer_t *)
-                        ( st->tmp+CLEANSIZ-sizeof(sprintf_buffer_t) );
-                    b->offset = -CLEANSIZ+(p_int)sizeof(sprintf_buffer_t);
-                    b->size = CLEANSIZ;
-                    b->start = &st->tmp;
-                    b = svalue_to_string(st, carg, b, 0, MY_FALSE
-                                        , (finfo & INFO_T) == INFO_T_QLPC
-                                        , (finfo & INFO_TABLE)
-                                        , MY_FALSE
-                                        );
-                    finfo &= ~INFO_TABLE; /* since we fall through */
+                        b = (sprintf_buffer_t *)
+                            ( st->tmp+CLEANSIZ-sizeof(sprintf_buffer_t) );
+                        b->offset = -CLEANSIZ+(p_int)sizeof(sprintf_buffer_t);
+                        b->size = CLEANSIZ;
+                        b->start = &st->tmp;
+                        b = svalue_to_string(st, carg, b, 0, MY_FALSE
+                                , (finfo & INFO_T) == INFO_T_QLPC
+                                , (finfo & INFO_TABLE)
+                                , MY_FALSE
+                                , pres
+                                );
+                        finfo &= ~INFO_TABLE; /* since we fall through */
+                        pres = 0; /* since we fall through */
+                        /* Store the created result in .clean and pass it
+                         * to case INFO_T_STRING is 'the' carg.
+                         */
+                        put_string(&st->clean, new_n_unicode_mstring(st->tmp, b->size + b->offset - (p_int)sizeof(sprintf_buffer_t) ));
+                        carg = &st->clean;
 
-                    /* Store the created result in .clean and pass it
-                     * to case INFO_T_STRING is 'the' carg.
-                     */
-                    put_string(&st->clean, new_n_unicode_mstring(st->tmp, b->size + b->offset - (p_int)sizeof(sprintf_buffer_t) ));
-                    carg = &st->clean;
-
-                    free_pointer_table(st->ptable);
-                    st->ptable = NULL;
-                    /* FALLTHROUGH */
-                  }
+                        free_pointer_table(st->ptable);
+                        st->ptable = NULL;
+                        /* FALLTHROUGH */
+                    }
 
                 case INFO_T_STRING:
-                  {
-                    mp_int slen;
-
-                    if (carg->type != T_STRING)
-                        ERROR1(ERR_INCORRECT_ARG, 's');
-                    slen = mstrsize(carg->u.str);
-
-                    if (finfo & (INFO_COLS | INFO_TABLE) )
                     {
-                        /* Add a new column/table info
-                         * ... this is complicated ...
-                         */
-                        cst **temp;
+                        mp_int slen;
 
-                        if (!fs)
-                            ERROR(ERR_CST_REQUIRES_FS);
+                        if (carg->type != T_STRING)
+                            ERROR1(ERR_INCORRECT_ARG, 's');
+                        slen = mstrsize(carg->u.str);
 
-                        if ((finfo & (INFO_COLS | INFO_TABLE))
-                          == (INFO_COLS | INFO_TABLE)
-                           )
-                            ERROR(ERR_INVALID_FORMAT_STR);
-
-                        /* Find the end of the list of columns/tables */
-                        temp = &st->csts;
-                        while (*temp)
-                            temp = &((*temp)->next);
-
-                        if (finfo & INFO_COLS)
+                        if (finfo & (INFO_COLS | INFO_TABLE) )
                         {
-                            /* Create a new columns structure */
-                            *temp = xalloc(sizeof(cst));
-                            if (!*temp)
-                                ERROR(ERR_NOMEM);
-                            (*temp)->next = NULL;
-                            (*temp)->d.col.str = get_txt(carg->u.str);
-                            (*temp)->d.col.len = slen;
-                            (*temp)->pad.str = pad;
-                            (*temp)->pad.len = padlen;
-                            (*temp)->size = fs;
-                            (*temp)->pres = (pres) ? (int)pres : (int)fs;
-                            (*temp)->info = finfo;
-                            (*temp)->start = get_string_width(st->buff + st->line_start, st->bpos - st->line_start, NULL);
+                            /* Add a new column/table info
+                             * ... this is complicated ...
+                             */
+                            cst **temp;
 
-                            /* Format the first line from the column */
-                            column_stat = add_column(st, temp);
-                        }
-                        else
-                        {
-                            /* (finfo & INFO_TABLE) */
-                            unsigned int n, len, max, pos, last_pos;
-                            int tpres;
-                            char *s, *start, *end;
-                            p_uint i;
+                            if (!fs)
+                                ERROR(ERR_CST_REQUIRES_FS);
+
+                            if ((finfo & (INFO_COLS | INFO_TABLE))
+                                    == (INFO_COLS | INFO_TABLE)
+                               )
+                                ERROR(ERR_INVALID_FORMAT_STR);
+
+                            /* Find the end of the list of columns/tables */
+                            temp = &st->csts;
+                            while (*temp)
+                                temp = &((*temp)->next);
+
+                            if (finfo & INFO_COLS)
+                            {
+                                /* Create a new columns structure */
+                                *temp = xalloc(sizeof(cst));
+                                if (!*temp)
+                                    ERROR(ERR_NOMEM);
+                                (*temp)->next = NULL;
+                                (*temp)->d.col.str = get_txt(carg->u.str);
+                                (*temp)->d.col.len = slen;
+                                (*temp)->pad.str = pad;
+                                (*temp)->pad.len = padlen;
+                                (*temp)->size = fs;
+                                (*temp)->pres = (pres) ? (int)pres : (int)fs;
+                                (*temp)->info = finfo;
+                                (*temp)->start = get_string_width(st->buff + st->line_start, st->bpos - st->line_start, NULL);
+
+                                /* Format the first line from the column */
+                                column_stat = add_column(st, temp);
+                            }
+                            else
+                            {
+                                /* (finfo & INFO_TABLE) */
+                                unsigned int n, len, max, pos, last_pos;
+                                int tpres;
+                                char *s, *start, *end;
+                                p_uint i;
 
 #                    define TABLE get_txt(carg->u.str)
 #                    define TABLELEN slen
 
-                            /* Create the new table structure */
-                            (*temp) = (cst *)xalloc(sizeof(cst));
-                            if (!*temp)
-                                ERROR(ERR_NOMEM);
-                            (*temp)->pad.str = pad;
-                            (*temp)->pad.len = padlen;
-                            (*temp)->info = finfo;
-                            (*temp)->start = get_string_width(st->buff + st->line_start, st->bpos - st->line_start, NULL);
-                            (*temp)->next = NULL;
+                                /* Create the new table structure */
+                                (*temp) = (cst *)xalloc(sizeof(cst));
+                                if (!*temp)
+                                    ERROR(ERR_NOMEM);
+                                (*temp)->pad.str = pad;
+                                (*temp)->pad.len = padlen;
+                                (*temp)->info = finfo;
+                                (*temp)->start = get_string_width(st->buff + st->line_start, st->bpos - st->line_start, NULL);
+                                (*temp)->next = NULL;
 
-                            /* Determine the size of the table */
-                            max = len = 0;
-                            n = 0;
-                            start = s = TABLE;
-                            end = s + TABLELEN;
-                            while (s != end)
-                            {
-                                bool error;
-
-                                while (*s != '\n')
+                                /* Determine the size of the table */
+                                max = len = 0;
+                                n = 0;
+                                start = s = TABLE;
+                                end = s + TABLELEN;
+                                while (s != end)
                                 {
-                                    s++;
-                                    if (s == end)
-                                        break;
-                                }
+                                    bool error;
 
-                                len = get_string_width(start, s - start, &error);
-                                if (error)
-                                    ERROR(ERR_INVALID_CHAR);
-                                if (len > max)
-                                    max = len;
-                                n++;
-
-                                if (s != end)
-                                    s++;
-                                start = s;
-                            } /* while() */
-
-                            if (n == 0)
-                                n = 1;
-
-                            /* Now: n = number of lines
-                             *      max = max length of the lines
-                             */
-
-                            tpres = pres;
-                            if (tpres)
-                            {
-                                (*temp)->size = fs/tpres;
-                            }
-                            else
-                            {
-                                tpres = fs/(max+2);
-                                  /* at least two separating spaces */
-                                if (!tpres)
-                                    tpres = 1;
-                                (*temp)->size = fs/tpres;
-                            }
-
-                            len = n/tpres; /* length of average column */
-
-                            if (n < (unsigned int)tpres)
-                                tpres = n;
-                            if (len*tpres < n)
-                                len++;
-                            /* Since the table will be filled by column,
-                             * the result will be a rectangle with as little
-                             * as possible empty space. This means we have
-                             * to adjust the no of columns (tpres) to
-                             * what the fill algorithm will actually
-                             * produce.
-                             */
-                            if (len > 1 && n%tpres)
-                                tpres -= (tpres - n%tpres)/len;
-
-                            (*temp)->d.tab = xalloc(tpres*sizeof(string_view_t));
-                            if (!(*temp)->d.tab)
-                                ERROR(ERR_NOMEM);
-                            (*temp)->nocols = tpres; /* heavy sigh */
-                            (*temp)->d.tab[0].str = TABLE;
-                            (*temp)->d.tab[0].len = TABLELEN;
-
-                            if (tpres == 1)
-                                goto add_table_now;
-
-                            /* Subformat the table, replacing some characters
-                             * in the given string.
-                             * The original chars are saved for later restoring.
-                             */
-                            i = 0; /* the current column number */
-                            n = 0; /* the current "word" number in this column */
-                            last_pos = 0;
-                            for (pos = 0; pos < TABLELEN; pos++)
-                            {
-                                /* Splitting the text here. */
-                                if (TABLE[pos] == '\n')
-                                {
-                                    if (++n >= len)
+                                    while (*s != '\n')
                                     {
-                                        (*temp)->d.tab[i].len = pos - last_pos;
-
-                                        last_pos = ++pos;
-                                        i++;
-                                        (*temp)->d.tab[i].str = TABLE+pos;
-
-                                        if (i+1 >= (unsigned int)tpres)
+                                        s++;
+                                        if (s == end)
                                             break;
-                                        n = 0;
                                     }
-                                }
-                            } /* for (fs) */
 
-                            (*temp)->d.tab[i].len = TABLELEN - last_pos;
+                                    len = get_string_width(start, s - start, &error);
+                                    if (error)
+                                        ERROR(ERR_INVALID_CHAR);
+                                    if (len > max)
+                                        max = len;
+                                    n++;
+
+                                    if (s != end)
+                                        s++;
+                                    start = s;
+                                } /* while() */
+
+                                if (n == 0)
+                                    n = 1;
+
+                                /* Now: n = number of lines
+                                 *      max = max length of the lines
+                                 */
+
+                                tpres = pres;
+                                if (tpres)
+                                {
+                                    (*temp)->size = fs/tpres;
+                                }
+                                else
+                                {
+                                    tpres = fs/(max+2);
+                                    /* at least two separating spaces */
+                                    if (!tpres)
+                                        tpres = 1;
+                                    (*temp)->size = fs/tpres;
+                                }
+
+                                len = n/tpres; /* length of average column */
+
+                                if (n < (unsigned int)tpres)
+                                    tpres = n;
+                                if (len*tpres < n)
+                                    len++;
+                                /* Since the table will be filled by column,
+                                 * the result will be a rectangle with as little
+                                 * as possible empty space. This means we have
+                                 * to adjust the no of columns (tpres) to
+                                 * what the fill algorithm will actually
+                                 * produce.
+                                 */
+                                if (len > 1 && n%tpres)
+                                    tpres -= (tpres - n%tpres)/len;
+
+                                (*temp)->d.tab = xalloc(tpres*sizeof(string_view_t));
+                                if (!(*temp)->d.tab)
+                                    ERROR(ERR_NOMEM);
+                                (*temp)->nocols = tpres; /* heavy sigh */
+                                (*temp)->d.tab[0].str = TABLE;
+                                (*temp)->d.tab[0].len = TABLELEN;
+
+                                if (tpres == 1)
+                                    goto add_table_now;
+
+                                /* Subformat the table, replacing some characters
+                                 * in the given string.
+                                 * The original chars are saved for later restoring.
+                                 */
+                                i = 0; /* the current column number */
+                                n = 0; /* the current "word" number in this column */
+                                last_pos = 0;
+                                for (pos = 0; pos < TABLELEN; pos++)
+                                {
+                                    /* Splitting the text here. */
+                                    if (TABLE[pos] == '\n')
+                                    {
+                                        if (++n >= len)
+                                        {
+                                            (*temp)->d.tab[i].len = pos - last_pos;
+
+                                            last_pos = ++pos;
+                                            i++;
+                                            (*temp)->d.tab[i].str = TABLE+pos;
+
+                                            if (i+1 >= (unsigned int)tpres)
+                                                break;
+                                            n = 0;
+                                        }
+                                    }
+                                } /* for (fs) */
+
+                                (*temp)->d.tab[i].len = TABLELEN - last_pos;
 
 add_table_now:
-                            /* Now add the table (at least the first line) */
-                            add_table(st, temp);
-                        }
-                    }
-                    else
-                    {
-                        Bool justifyString;
-                        bool error = false;
-                        size_t reallen = get_string_width(get_txt(carg->u.str), slen, &error);
-
-                        if (error)
-                            ERROR(ERR_INVALID_CHAR);
-
-                        /* not column or table */
-                        if (pres && pres < reallen)
-                        {
-                            reallen = pres;
-                            slen = get_string_up_to_width(get_txt(carg->u.str), slen, pres, NULL);
-                        }
-
-                        /* Determine whether to print this string
-                         * justified, or not.
-                         */
-                        justifyString = MY_FALSE;
-                        if (fs && (finfo & INFO_A) == INFO_A_JUSTIFY)
-                        {
-                            /* Flush the string only if it doesn't
-                             * end in a NL.
-                             * Also, strip off trailing spaces.
-                             */
-                            for ( ;    slen > 0
-                                    && get_txt(carg->u.str)[slen-1] == ' '
-                                  ; slen--, reallen--
-                               ) NOOP;
-
-                            if ( slen != 0
-                              && (unsigned int)reallen <= fs
-                              && get_txt(carg->u.str)[slen-1] != '\n'
-                               )
-                                justifyString = MY_TRUE;
-                        }
-
-                        /* not column or table */
-
-                        if (justifyString)
-                        {
-                            add_justified(st, get_txt(carg->u.str), slen, fs);
-                        }
-                        else if (fs && fs > reallen)
-                        {
-                            add_aligned(st, get_txt(carg->u.str)
-                                       , slen, pad, padlen, fs, finfo);
+                                /* Now add the table (at least the first line) */
+                                add_table(st, temp);
+                            }
                         }
                         else
                         {
-                            ADD_STRN(st, get_txt(carg->u.str), slen);
+                            Bool justifyString;
+                            bool error = false;
+                            size_t reallen = get_string_width(get_txt(carg->u.str), slen, &error);
+
+                            if (error)
+                                ERROR(ERR_INVALID_CHAR);
+
+                            /* not column or table */
+                            if (pres && pres < reallen)
+                            {
+                                reallen = pres;
+                                slen = get_string_up_to_width(get_txt(carg->u.str), slen, pres, NULL);
+                            }
+
+                            /* Determine whether to print this string
+                             * justified, or not.
+                             */
+                            justifyString = MY_FALSE;
+                            if (fs && (finfo & INFO_A) == INFO_A_JUSTIFY)
+                            {
+                                /* Flush the string only if it doesn't
+                                 * end in a NL.
+                                 * Also, strip off trailing spaces.
+                                 */
+                                for ( ;    slen > 0
+                                        && get_txt(carg->u.str)[slen-1] == ' '
+                                        ; slen--, reallen--
+                                    ) NOOP;
+
+                                if ( slen != 0
+                                        && (unsigned int)reallen <= fs
+                                        && get_txt(carg->u.str)[slen-1] != '\n'
+                                   )
+                                    justifyString = MY_TRUE;
+                            }
+
+                            /* not column or table */
+
+                            if (justifyString)
+                            {
+                                add_justified(st, get_txt(carg->u.str), slen, fs);
+                            }
+                            else if (fs && fs > reallen)
+                            {
+                                add_aligned(st, get_txt(carg->u.str)
+                                        , slen, pad, padlen, fs, finfo);
+                            }
+                            else
+                            {
+                                ADD_STRN(st, get_txt(carg->u.str), slen);
+                            }
                         }
+                        break;
                     }
-                    break;
-                  }
 
                 case INFO_T_INT:
                 case INFO_T_FLOAT:
                     /* We 'cheat' by using the systems sprintf() to format
                      * the number in most of the formats.
                      */
-                  if ((finfo & INFO_T ) == INFO_T_INT
-                   && (format_char == 'b' || format_char == 'B')
-                     )
-                  {
-                    /* Dummy for finding most significant bit */
-                    int signi = 0;
-                    int isize = sizeof(carg->u.number) * CHAR_BIT;
-                    char temp[sizeof(carg->u.number) * CHAR_BIT + 1];
-                    
-                    memset(temp, '\0', sizeof(temp));
-                    
-                    if (carg->type != T_NUMBER)
+                    if ((finfo & INFO_T ) == INFO_T_INT
+                            && (format_char == 'b' || format_char == 'B')
+                       )
                     {
-                        ERROR1(ERR_INCORRECT_ARG, format_char);
-                    }
-                    /* Calculate binary representation (2's compliment) */
-                    size_t tmpl = sizeof(temp);
-                    // only strcat if at least 2 bytes (1 byte after this bit) left
-                    while ( --isize > -1  && tmpl >= 1)
-                    {
-                       if ( ( carg->u.number & ( (p_uint)1 << isize ) ) != 0 )
-                       {
-                          // Gnomi: strcat is quite inefficient. isize
-                          // or tmpl could be used for direct indexing
-                          // (temp[sizeof(temp)-tmpl-1] = '0')
-                          // True. But strcat is much more readable, this code is
-                          // anyway crappy to read. And this particular piece here
-                          // is executed really seldom. Very few people want to
-                          // print numbers in binary representation and if they to,
-                          // they use mostly small numbers.
-                          signi = 1;
-                          strcat( temp, "1" );
-                          --tmpl;
-                       }
-                       else if ( signi || !isize)
-                       {
-                          strcat( temp, "0" );
-                          --tmpl;
-                       }
-                    }
-                    // if still bits left, but buffer is full, throw error.
-                    if (isize > -1 && tmpl < 1)
-                        ERROR(ERR_LOCAL_BUFF_OVERFLOW);
-                    if (pres && tmpl > pres)
-                        tmpl = pres; /* well.... */
-                    if ((unsigned int)tmpl < fs)
-                        add_aligned(st, temp, sizeof(temp) - tmpl, pad, padlen, fs, finfo);
-                    else
-                        ADD_STRN(st, temp, sizeof(temp) - tmpl);
-                    break;
-                  }
-                  else if ((finfo & INFO_T ) == INFO_T_INT && format_char == 'c')
-                  {
-                    char temp[4];
-                    size_t clen = unicode_to_utf8(carg->u.number, temp);
-                    if (!clen)
-                        ERROR1(ERR_INCORRECT_ARG, 'c');
+                        /* Dummy for finding most significant bit */
+                        int signi = 0;
+                        int isize = sizeof(carg->u.number) * CHAR_BIT;
+                        char temp[sizeof(carg->u.number) * CHAR_BIT + 1];
 
-                    ADD_STRN(st, temp, clen);
-                    break;
-                  }
-                  else
-                  {
-                    /* Synthesized format for sprintf() */
-                    char cheat[6+sizeof(PRI_PINT_PREFIX)-1];
-                    char temp[1024];
-                      /* The buffer must be big enough to hold the biggest float
-                       * in non-exponential representation. 1 KByte is hopefully
-                       * far on the safe side.
-                       * TODO: Allocate it dynamically?
-                       */
-                    double value;   /* The value to print */
-                    int    numdig;  /* (Estimated) number of digits before the '.' */
-                    Bool zeroCharHack = MY_FALSE;
-                    char *p = cheat; /* pointer to the format buffer */
-                    size_t tmpl; // no of bytes written to buffer temp
+                        memset(temp, '\0', sizeof(temp));
 
-                    *(p++) = '%';
-                    switch (finfo & INFO_PP)
-                    {
-                        case INFO_PP_SPACE: *(p++) = ' '; break;
-                        case INFO_PP_PLUS:  *(p++) = '+'; break;
-                    }
-                    if ((finfo & INFO_T) == INFO_T_FLOAT)
-                    {
-                        if (carg->type != T_FLOAT) /* sigh... */
+                        if (carg->type != T_NUMBER)
                         {
                             ERROR1(ERR_INCORRECT_ARG, format_char);
                         }
-                        *(p++) = '.';
-                        *(p++) = '*';
-                        *(p++) = format_char;
-                        *p = '\0';
-
-                        value = READ_DOUBLE(carg);
-
-                        if ('e' == format_char
-                         || 'E' == format_char
-                         || fabs(value) < 1.0)
-                            numdig = 1;
-                        else
-                            numdig = (int) ceil(log10(fabs(value)));
-                        if (value < 0.0)
-                            numdig++;
-
-                        if ((size_t)pres > (sizeof(temp) - 12 - numdig))
+                        /* Calculate binary representation (2's compliment) */
+                        size_t tmpl = sizeof(temp);
+                        // only strcat if at least 2 bytes (1 byte after this bit) left
+                        while ( --isize > -1  && tmpl >= 1)
                         {
-                            pres = sizeof(temp) - 12 - numdig;
-                        }
-                        tmpl = snprintf(temp, sizeof(temp), cheat, pres, READ_DOUBLE(carg));
-                        if (tmpl >= sizeof(temp))
-                            ERROR(ERR_LOCAL_BUFF_OVERFLOW);
-                            /* NOT REACHED */
-                    }
-                    else
-                    {
-                        if (carg->type != T_NUMBER) /* sigh... */
-                        {
-                            ERROR1(ERR_INCORRECT_ARG, format_char);
-                        }
-
-                        /* insert the correct length modifier for a p_int
-                         * type. (If the prefix is an empty string, this will
-                         * be probably optimized by the compiler anyway. */
-                        else {
-                            p = memcpy(p, PRI_PINT_PREFIX,
-                                          strlen(PRI_PINT_PREFIX));
-                            p += strlen(PRI_PINT_PREFIX);
-                        }
-                        *(p++) = format_char;
-                        *p = '\0';
-                        tmpl = snprintf(temp, sizeof(temp), cheat, carg->u.number);
-                        if (tmpl >= sizeof(temp))
-                            ERROR(ERR_LOCAL_BUFF_OVERFLOW);
-
-                        if (pres && tmpl > pres)
-                            tmpl = pres; /* well.... */
-
-                        if (zeroCharHack)
-                        {
-                            int pos;
-                            for (pos = 0; pos < tmpl; ++pos)
+                            if ( ( carg->u.number & ( (p_uint)1 << isize ) ) != 0 )
                             {
-                                if (temp[pos] == 0x01)
-                                    temp[pos] = 0x00;
+                                // Gnomi: strcat is quite inefficient. isize
+                                // or tmpl could be used for direct indexing
+                                // (temp[sizeof(temp)-tmpl-1] = '0')
+                                // True. But strcat is much more readable, this code is
+                                // anyway crappy to read. And this particular piece here
+                                // is executed really seldom. Very few people want to
+                                // print numbers in binary representation and if they to,
+                                // they use mostly small numbers.
+                                signi = 1;
+                                strcat( temp, "1" );
+                                --tmpl;
+                            }
+                            else if ( signi || !isize)
+                            {
+                                strcat( temp, "0" );
+                                --tmpl;
                             }
                         }
-                    }
-                    if ((unsigned int)tmpl < fs)
-                    {
-                        if ((finfo & INFO_PS_ZERO) != 0
-                         && (   temp[0] == ' '
-                             || temp[0] == '+'
-                             || temp[0] == '-'
-                            )
-                         && (finfo & INFO_A) != INFO_A_LEFT
-                           )
-                        {
-                            /* Non-left alignment and we're printing
-                             * with leading zeroes: preserve the sign
-                             * character in the right place.
-                             */
-                            ADD_STRN(st, temp, 1);
-                            add_aligned(st, temp+1, tmpl-1, pad, padlen, fs-1, finfo);
-                        }
+                        // if still bits left, but buffer is full, throw error.
+                        if (isize > -1 && tmpl < 1)
+                            ERROR(ERR_LOCAL_BUFF_OVERFLOW);
+                        if (pres && tmpl > pres)
+                            tmpl = pres; /* well.... */
+                        if ((unsigned int)tmpl < fs)
+                            add_aligned(st, temp, sizeof(temp) - tmpl, pad, padlen, fs, finfo);
                         else
-                            add_aligned(st, temp, tmpl, pad, padlen, fs, finfo);
+                            ADD_STRN(st, temp, sizeof(temp) - tmpl);
+                        break;
+                    }
+                    else if ((finfo & INFO_T ) == INFO_T_INT && format_char == 'c')
+                    {
+                        char temp[4];
+                        size_t clen = unicode_to_utf8(carg->u.number, temp);
+                        if (!clen)
+                            ERROR1(ERR_INCORRECT_ARG, 'c');
+
+                        ADD_STRN(st, temp, clen);
+                        break;
                     }
                     else
-                        ADD_STRN(st, temp, tmpl);
-                    break;
-                  }
+                    {
+                        /* Synthesized format for sprintf() */
+                        char cheat[6+sizeof(PRI_PINT_PREFIX)-1];
+                        char temp[1024];
+                        /* The buffer must be big enough to hold the biggest float
+                         * in non-exponential representation. 1 KByte is hopefully
+                         * far on the safe side.
+                         * TODO: Allocate it dynamically?
+                         */
+                        double value;   /* The value to print */
+                        int    numdig;  /* (Estimated) number of digits before the '.' */
+                        Bool zeroCharHack = MY_FALSE;
+                        char *p = cheat; /* pointer to the format buffer */
+                        size_t tmpl; // no of bytes written to buffer temp
+
+                        *(p++) = '%';
+                        switch (finfo & INFO_PP)
+                        {
+                            case INFO_PP_SPACE: *(p++) = ' '; break;
+                            case INFO_PP_PLUS:  *(p++) = '+'; break;
+                        }
+                        if ((finfo & INFO_T) == INFO_T_FLOAT)
+                        {
+                            if (carg->type != T_FLOAT) /* sigh... */
+                            {
+                                ERROR1(ERR_INCORRECT_ARG, format_char);
+                            }
+                            *(p++) = '.';
+                            *(p++) = '*';
+                            *(p++) = format_char;
+                            *p = '\0';
+
+                            value = READ_DOUBLE(carg);
+
+                            if ('e' == format_char
+                                    || 'E' == format_char
+                                    || fabs(value) < 1.0)
+                                numdig = 1;
+                            else
+                                numdig = (int) ceil(log10(fabs(value)));
+                            if (value < 0.0)
+                                numdig++;
+
+                            if ((size_t)pres > (sizeof(temp) - 12 - numdig))
+                            {
+                                pres = sizeof(temp) - 12 - numdig;
+                            }
+                            tmpl = snprintf(temp, sizeof(temp), cheat, pres, READ_DOUBLE(carg));
+                            if (tmpl >= sizeof(temp))
+                                ERROR(ERR_LOCAL_BUFF_OVERFLOW);
+                            /* NOT REACHED */
+                        }
+                        else
+                        {
+                            if (carg->type != T_NUMBER) /* sigh... */
+                            {
+                                ERROR1(ERR_INCORRECT_ARG, format_char);
+                            }
+
+                            /* insert the correct length modifier for a p_int
+                             * type. (If the prefix is an empty string, this will
+                             * be probably optimized by the compiler anyway. */
+                            else {
+                                p = memcpy(p, PRI_PINT_PREFIX,
+                                        strlen(PRI_PINT_PREFIX));
+                                p += strlen(PRI_PINT_PREFIX);
+                            }
+                            *(p++) = format_char;
+                            *p = '\0';
+                            tmpl = snprintf(temp, sizeof(temp), cheat, carg->u.number);
+                            if (tmpl >= sizeof(temp))
+                                ERROR(ERR_LOCAL_BUFF_OVERFLOW);
+
+                            if (pres && tmpl > pres)
+                                tmpl = pres; /* well.... */
+
+                            if (zeroCharHack)
+                            {
+                                int pos;
+                                for (pos = 0; pos < tmpl; ++pos)
+                                {
+                                    if (temp[pos] == 0x01)
+                                        temp[pos] = 0x00;
+                                }
+                            }
+                        }
+                        if ((unsigned int)tmpl < fs)
+                        {
+                            if ((finfo & INFO_PS_ZERO) != 0
+                                    && (   temp[0] == ' '
+                                        || temp[0] == '+'
+                                        || temp[0] == '-'
+                                       )
+                                    && (finfo & INFO_A) != INFO_A_LEFT
+                               )
+                            {
+                                /* Non-left alignment and we're printing
+                                 * with leading zeroes: preserve the sign
+                                 * character in the right place.
+                                 */
+                                ADD_STRN(st, temp, 1);
+                                add_aligned(st, temp+1, tmpl-1, pad, padlen, fs-1, finfo);
+                            }
+                            else
+                                add_aligned(st, temp, tmpl, pad, padlen, fs, finfo);
+                        }
+                        else
+                            ADD_STRN(st, temp, tmpl);
+                        break;
+                    }
                 default:        /* type not found */
                     ERROR(ERR_UNDEFINED_TYPE);
-                }
+            }
 
-                if (!(finfo & INFO_ARRAY))
-                    break;
+            if (!(finfo & INFO_ARRAY))
+                break;
 
-                if (nelemno >= (size_t)VEC_SIZE((argv+arg)->u.vec))
-                    break;
+            if (nelemno >= (size_t)VEC_SIZE((argv+arg)->u.vec))
+                break;
 
-                carg = (argv+arg)->u.vec->item+nelemno++;
-            } /* end of while (1) */
-            fpos--; /* bout to get incremented */
-            continue;
-        } /* if format entry */
+            carg = (argv+arg)->u.vec->item+nelemno++;
+        } /* end of while (1) */
+        fpos--; /* bout to get incremented */
+        continue;
+    } /* if format entry */
 
-        /* Nothing to format: just copy the character */
-        ADD_CHAR(st, format_str[fpos]);
-    } /* for (fpos=0; 1; fpos++) */
+    /* Nothing to format: just copy the character */
+    ADD_CHAR(st, format_str[fpos]);
+} /* for (fpos=0; 1; fpos++) */
 
-    /* Free the temp string */
-    if (st->clean.u.str)
-        free_mstring(st->clean.u.str);
-    if (st->tmp)
-        xfree(st->tmp);
+/* Free the temp string */
+if (st->clean.u.str)
+    free_mstring(st->clean.u.str);
+if (st->tmp)
+    xfree(st->tmp);
 
     /* Copy over the result */
-    if  (st->bpos > 0)
-        result = new_n_unicode_mstring(st->buff, st->bpos);
+if  (st->bpos > 0)
+    result = new_n_unicode_mstring(st->buff, st->bpos);
     else
-        result = ref_mstring(STR_EMPTY);
-    if (!result)
-        result = ref_mstring(STR_OUT_OF_MEMORY);
+    result = ref_mstring(STR_EMPTY);
+if (!result)
+    result = ref_mstring(STR_OUT_OF_MEMORY);
 
-    if (st == &static_fmt)
-        static_fmt_used = MY_FALSE;
+if (st == &static_fmt)
+    static_fmt_used = MY_FALSE;
     else
-        xfree(st);
+    xfree(st);
 
     /* Done */
     return result;
 
 #undef GET_NEXT_ARG
 
-} /* string_print_formatted() */
+    } /* string_print_formatted() */
 
 /*-------------------------------------------------------------------------*/
 svalue_t *
 v_printf (svalue_t *sp, int num_arg)
 
-/* EFUN printf()
- *
- *   void printf(string format, ...)
- *
- * A cross between sprintf() and write(). Returns void and prints
- * the result string to the user.
- */
+    /* EFUN printf()
+     *
+     *   void printf(string format, ...)
+     *
+     * A cross between sprintf() and write(). Returns void and prints
+     * the result string to the user.
+     */
 
 {
     string_t *str;
     string_t *format = sp[1-num_arg].u.str;
 
     str = string_print_formatted(get_txt(format), mstrsize(format)
-                                , num_arg-1, sp-num_arg+2);
+            , num_arg-1, sp-num_arg+2);
     if (command_giver)
         tell_object(command_giver, str);
     else
@@ -2658,23 +2723,23 @@ v_printf (svalue_t *sp, int num_arg)
 svalue_t *
 v_sprintf (svalue_t *sp, int num_arg)
 
-/* EFUN sprintf()
- *
- *   string sprintf(string fmt, ...)
- *
- * Generate a string according to the <fmt> and the following
- * arguments and put it onto the stack.
- *
- * <fmt> follows the C-style sprintf-format string in style,
- * and partly in meaning, too.
- */
+    /* EFUN sprintf()
+     *
+     *   string sprintf(string fmt, ...)
+     *
+     * Generate a string according to the <fmt> and the following
+     * arguments and put it onto the stack.
+     *
+     * <fmt> follows the C-style sprintf-format string in style,
+     * and partly in meaning, too.
+     */
 
 {
     string_t *s;
     string_t *format = sp[1-num_arg].u.str;
 
     s = string_print_formatted(get_txt(format), mstrsize(format),
-                               num_arg-1, sp-num_arg+2);
+            num_arg-1, sp-num_arg+2);
     sp = pop_n_elems(num_arg, sp);
     if (!s)
         push_number(sp, 0);

--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -270,7 +270,7 @@ struct stsf_locals
     sprintf_buffer_t *spb;  /* Target buffer */
     int depth;              /* Recursion depth */
     int maxDepth;           /* Max recursion depth */
-    int count;
+    int count;              /* current element count */
     int maxCount;           /* Max number of elements */
     int num_values;         /* Mapping width */
     Bool quote;             /* TRUE: Quote strings */
@@ -710,7 +710,8 @@ svalue_to_string ( fmt_state_t *st
                  , int depth, Bool trailing, Bool quoteStrings
                  , Bool compact, Bool prefixed, int maxDepth, int maxCount)
 
-/* Print the value <obj> into the buffer <str> with recursion deptth <depth>.
+/* Print the value <obj> into the buffer <str> with <depth>*SPRINTF_LPC_INDENT
+ * spaces of indentation.
  * If <trailing> is true, add ",\n" after the printed value.
  * If <qoute> is true, special characters in strings are quoted LPC-style.
  * If <compact> is true, a short output format is used.
@@ -745,10 +746,7 @@ svalue_to_string ( fmt_state_t *st
                 break;
 
             case LVALUE_PROTECTED:
-                if (depth >= maxDepth)
-                    stradd(st, &str, "...");
-                else
-                    str = svalue_to_string(st, &(obj->u.protected_lvalue->val), str, depth+1, MY_FALSE, quoteStrings, compact, MY_TRUE, maxDepth, maxCount);
+                str = svalue_to_string(st, &(obj->u.protected_lvalue->val), str, depth+1, MY_FALSE, quoteStrings, compact, MY_TRUE, maxDepth, maxCount);
                 break;
 
             case LVALUE_PROTECTED_CHAR:
@@ -856,16 +854,20 @@ svalue_to_string ( fmt_state_t *st
                     }
 
                     default:
-                    stradd(st, &str, "!ERROR: GARBAGE RANGE TYPE (");
-                    numadd(st, &str, vec->type);
-                    stradd(st, &str, ")!");
-                    break;
+                    {
+                        stradd(st, &str, "!ERROR: GARBAGE RANGE TYPE (");
+                        numadd(st, &str, vec->type);
+                        stradd(st, &str, ")!");
+                        break;
+                    }
                 }
                 break;
             }
 
             case LVALUE_PROTECTED_MAPENTRY:
-            return svalue_to_string(st, get_rvalue(obj, NULL), str, depth, trailing, quoteStrings, compact, prefixed, maxDepth, maxCount);
+            {
+                return svalue_to_string(st, get_rvalue(obj, NULL), str, depth, trailing, quoteStrings, compact, prefixed, maxDepth, maxCount);
+            }
 
             case LVALUE_PROTECTED_MAP_RANGE:
             {

--- a/src/sprintf.h
+++ b/src/sprintf.h
@@ -7,4 +7,7 @@
 extern svalue_t *v_printf(svalue_t *sp, int num_arg);
 extern svalue_t *v_sprintf(svalue_t *sp, int num_arg);
 
+#define SPRINTF_LPC_INDENT 2
+
+
 #endif /* SPRINTF_H__ */


### PR DESCRIPTION
This implements additional formatting options for sprintf's %O and %Q modifiers.

- `%nO`/`%nQ`: 'field width' is interpreted as maximum recursion depth into arrays/mappings/structs.
- `%.nO`/`%.nQ`: 'precision' is interpreted as maximum number of array/mapping/struct elements to print.
- `%n.nO`/`%n.nQ`: both limits can be set independently, or.
- `%:nO`/`%:nQ`: both limits can be set simultaneously, as usual.

If the one of the limits is reached, further elements/substructures are omited and "..." is printed instead.