### PR TITLE
simul-efuns for alists

### DIFF
--- a/mudlib/deprecated/alists_sorted.c
+++ b/mudlib/deprecated/alists_sorted.c
@@ -15,8 +15,6 @@
    which offers much better performance for some operations.
  */
 
-#pragma rtt_checks
-
 #ifndef __ALISTS__
 /*
    Helper function used by insert_alist()
@@ -49,7 +47,7 @@ private varargs void
 assert_alist(mixed * alist, string context = "")
 {
     if (!efun::sizeof(alist) || !efun::pointerp(alist[0]))
-        efun::raise_error(context + "Not an alist.\n");
+        efun::raise_error(context + "Missing key array.\n");
 
     int keynum = efun::sizeof(alist[0]);
     for (int i = efun::sizeof(alist); i-->1;)
@@ -70,6 +68,9 @@ assert_alist(mixed * alist, string context = "")
 varargs mixed
 assoc(mixed key, mixed * keys_or_alist, mixed data_or_fail, mixed fail)
 {
+    if (!efun::pointerp(keys_or_alist))
+        raise_error("Bad argument 2 to assoc().\n");
+
     // case 3: mixed assoc(mixed key, mixed *keys, mixed *data [, mixed fail])
     if (efun::pointerp(data_or_fail))
     {
@@ -164,6 +165,9 @@ insert_alist(mixed key, varargs mixed * args)
 mixed *
 order_alist(mixed * keys, varargs mixed * data)
 {
+    if (!efun::pointerp(keys))
+        raise_error("Bad argument 1 to order_alist().\n");
+
     // whole alist given -> split into components
     if (!efun::sizeof(data))
     {

--- a/mudlib/deprecated/alists_sorted.c
+++ b/mudlib/deprecated/alists_sorted.c
@@ -125,7 +125,8 @@ insert_alist(mixed key, varargs mixed * args)
         // new key
         idx = -idx - 1;
         // update arg if given by reference
-        args[0][idx..idx-1] = ({ key });
+        if (referencep(&(args[0])))
+            args[0][idx..idx-1] = ({ key });
         return idx;
     }
 
@@ -156,6 +157,11 @@ insert_alist(mixed key, varargs mixed * args)
         }
     }
 
+    /*
+    // update arg if it was given by reference
+    if (referencep(&(args[<1])))
+        args[<1] = alist;
+     */
     return alist;
 }
 

--- a/mudlib/deprecated/alists_sorted.c
+++ b/mudlib/deprecated/alists_sorted.c
@@ -19,8 +19,9 @@
    the key array in-place. This simul-efun checks if the key or value array
    was passed by reference and does an in-place update in that case.
    If you need the function to behave _strictly_ as originally implemented,
-   please remove the respective sections (marked as OPTIONAL) below.
+   just remove the following define.
  */
+#define ALISTS_INPLACE_UPDATE
 
 #ifndef __ALISTS__
 /*
@@ -132,10 +133,10 @@ insert_alist(mixed key, varargs mixed * args)
         // new key
         idx = -idx - 1;
 
-        // OPTIONAL: update arg if passed by reference
+#ifdef ALISTS_INPLACE_UPDATE
         if (referencep(&(args[0])))
             args[0][idx..idx-1] = ({ key });
-        // *******************************************
+#endif
 
         return idx;
     }
@@ -167,10 +168,10 @@ insert_alist(mixed key, varargs mixed * args)
         }
     }
 
-    // OPTIONAL: update arg if passed by reference
+#ifdef ALISTS_INPLACE_UPDATE
     if (referencep(&(args[<1])))
         args[<1] = alist;
-    // *******************************************
+#endif
 
     return alist;
 }

--- a/mudlib/deprecated/alists_sorted.c
+++ b/mudlib/deprecated/alists_sorted.c
@@ -1,0 +1,193 @@
+/*
+   simul-efun replacement for alists
+   by Coogan@Tubmud & Invisible@Beutelland
+
+   IMPORTANT:
+   This implementation uses sorted key arrays. For this reason it only
+   supports integer and string keys, and all keys in an alist must be of
+   the same type!
+
+   This is intended for Libs that rely on integer keys being in ascending
+   order (which was coincidentally the case in the old driver implementation;
+   it did not hold true for other types).
+
+   If you don't rely on sorted keys you can use alists_unsorted.c instead
+   which offers much better performance for some operations.
+ */
+
+#pragma rtt_checks
+
+#ifndef __ALISTS__
+/*
+   Helper function used by insert_alist()
+
+   returns index of key if found, or -index-1 where key should be inserted
+ */
+private int
+alist_lookup_key(mixed key, mixed * keys)
+{
+    /* simple approach using member()
+       this is slightly slower than a binary search for very large alists
+       but doesn't really make a huge difference in practice */
+
+    int idx = efun::member(keys, key);
+    if (idx >= 0) return idx;
+
+    // no need to search if key is outside existing range
+    if (key < keys[0]) return -1;
+    if (key > keys[<1]) return -efun::sizeof(keys) - 1;
+
+    return -efun::member(efun::sort_array(keys + ({ key }), #'>), key) - 1;
+}
+
+/*
+   Helper function used in assoc(), order_alist(), and insert_alist()
+
+   check alist for consistency, raise error if not properly formed
+ */
+private varargs void
+assert_alist(mixed * alist, string context = "")
+{
+    if (!efun::sizeof(alist) || !efun::pointerp(alist[0]))
+        efun::raise_error(context + "Not an alist.\n");
+
+    int keynum = efun::sizeof(alist[0]);
+    for (int i = efun::sizeof(alist); i-->1;)
+    {
+        if (!efun::pointerp(alist[i]) || efun::sizeof(alist[i]) != keynum)
+            efun::raise_error(context + "Type or size mismatch of the data arrays.\n");
+    }
+}
+
+
+/*
+   key or data retrieval
+
+   case 1: int   assoc(mixed key, mixed *keys)
+   case 2: mixed assoc(mixed key, mixed *alist [, mixed fail])
+   case 3: mixed assoc(mixed key, mixed *keys, mixed *data [, mixed fail])
+ */
+varargs mixed
+assoc(mixed key, mixed * keys_or_alist, mixed data_or_fail, mixed fail)
+{
+    // case 3: mixed assoc(mixed key, mixed *keys, mixed *data [, mixed fail])
+    if (efun::pointerp(data_or_fail))
+    {
+        if (efun::sizeof(keys_or_alist) != efun::sizeof(data_or_fail))
+            efun::raise_error("Number of keys and values differ.\n");
+
+        int idx = efun::member(keys_or_alist, key);
+        return idx < 0 ? fail : data_or_fail[idx];
+    }
+
+    // case 2: mixed assoc(mixed key, mixed *alist [, mixed fail])
+    if (efun::sizeof(keys_or_alist) && efun::pointerp(keys_or_alist[0]))
+    {
+        assert_alist(keys_or_alist, "Bad argument 2 to assoc(): ");
+
+        int idx = efun::member(keys_or_alist[0], key);
+        return idx < 0 ? data_or_fail : keys_or_alist[1][idx];
+    }
+
+    // case 1: int assoc(mixed key, mixed *keys)
+    if (data_or_fail)
+        efun::raise_error("Bad number of arguments to assoc().\n");
+
+    return efun::member(keys_or_alist, key);
+}
+
+/*
+   key or data insertion
+
+   case 1: mixed * insert_alist(mixed key, mixed data..., mixed * alist)
+   case 2: int     insert_alist(mixed key, mixed * keys)
+ */
+mixed
+insert_alist(mixed key, varargs mixed * args)
+{
+    if (!efun::sizeof(args))
+        raise_error("Missing argument to insert_alist().\n");
+
+    // case 2: int insert_alist(mixed key, mixed * keys)
+    if (efun::sizeof(args) == 1)
+    {
+        if (!efun::pointerp(args[0])
+                || (efun::sizeof(args[0])
+                    && !efun::intp(args[0][0])
+                    && !efun::stringp(args[0][0])))
+            efun::raise_error("Bad argument 2 to insert_alist().\n");
+
+        int idx = alist_lookup_key(key, args[0]);
+
+        if (idx >= 0) return idx; // existing key
+
+        // new key
+        idx = -idx - 1;
+        // update arg if given by reference
+        args[0][idx..idx-1] = ({ key });
+        return idx;
+    }
+
+    // case 1: mixed * insert_alist(mixed key, mixed data..., mixed * alist)
+    assert_alist(args[<1],
+            "Bad argument " + efun::sizeof(args) + " to insert_alist(): ");
+
+    mixed * alist = efun::deep_copy(args[<1]);
+
+    int idx = alist_lookup_key(key, alist[0]);
+    if (idx >= 0)
+    {
+        // existing key
+        for (int i = efun::sizeof(alist); i-->1;)
+        {
+            alist[i][idx] = args[i-1];
+        }
+    }
+    else
+    {
+        // new key
+        idx = -idx - 1;
+        alist[0][idx..idx-1] = ({ key });
+
+        for (int i = efun::sizeof(alist); i-->1;)
+        {
+            alist[i][idx..idx-1] = ({ args[i-1] });
+        }
+    }
+
+    return alist;
+}
+
+/*
+   sort keys and apply same permutation to the associated values
+ */
+mixed *
+order_alist(mixed * keys, varargs mixed * data)
+{
+    // whole alist given -> split into components
+    if (!efun::sizeof(data))
+    {
+        return order_alist(keys...);
+    }
+
+    mixed * alist = ({ keys }) + data;
+    assert_alist(alist, "Bad argument(s) to order_alist(): ");
+
+    return efun::transpose_array(
+            efun::sort_array(
+                efun::transpose_array(alist),
+                (: $1[0] > $2[0] :)
+                )
+            );
+}
+
+/*
+   intersect two lists, preserving the order of the first
+ */
+mixed *
+intersect_alist(mixed * list1, mixed * list2)
+{
+    return list1 & list2;
+}
+
+#endif

--- a/mudlib/deprecated/alists_sorted.c
+++ b/mudlib/deprecated/alists_sorted.c
@@ -13,6 +13,13 @@
 
    If you don't rely on sorted keys you can use alists_unsorted.c instead
    which offers much better performance for some operations.
+
+   IMPORTANT NOTE on insert_alist():
+   Contrary to the original documentation, the actual efun _never_ updated
+   the key array in-place. This simul-efun checks if the key or value array
+   was passed by reference and does an in-place update in that case.
+   If you need the function to behave _strictly_ as originally implemented,
+   please remove the respective sections (marked as OPTIONAL) below.
  */
 
 #ifndef __ALISTS__
@@ -124,9 +131,12 @@ insert_alist(mixed key, varargs mixed * args)
 
         // new key
         idx = -idx - 1;
-        // update arg if given by reference
+
+        // OPTIONAL: update arg if passed by reference
         if (referencep(&(args[0])))
             args[0][idx..idx-1] = ({ key });
+        // *******************************************
+
         return idx;
     }
 
@@ -157,11 +167,11 @@ insert_alist(mixed key, varargs mixed * args)
         }
     }
 
-    /*
-    // update arg if it was given by reference
+    // OPTIONAL: update arg if passed by reference
     if (referencep(&(args[<1])))
         args[<1] = alist;
-     */
+    // *******************************************
+
     return alist;
 }
 

--- a/mudlib/deprecated/alists_unsorted.c
+++ b/mudlib/deprecated/alists_unsorted.c
@@ -15,8 +15,9 @@
    the key array in-place. This simul-efun checks if the key or value array
    was passed by reference and does an in-place update in that case.
    If you need the function to behave _strictly_ as originally implemented,
-   please remove the respective sections (marked as OPTIONAL) below.
+   just remove the follofing define.
  */
+#define ALISTS_INPLACE_UPDATE
 
 #ifndef __ALISTS__
 
@@ -104,11 +105,11 @@ insert_alist(mixed key, varargs mixed * args)
 
         if (idx >= 0) return idx; // existing key
 
-        // OPTIONAL: update arg if passed by reference
+#ifdef ALISTS_INPLACE_UPDATE
         if (referencep(&(args[0])))
             args[0] += ({ key });
-        // *******************************************
-        
+#endif
+
         return efun::sizeof(args[0]) - 1;
     }
 
@@ -138,10 +139,10 @@ insert_alist(mixed key, varargs mixed * args)
         }
     }
 
-    // OPTIONAL: update arg if passed by reference
+#ifdef ALISTS_INPLACE_UPDATE
     if (referencep(&(args[<1])))
         args[<1] = alist;
-    // *******************************************
+#endif
 
     return alist;
 }

--- a/mudlib/deprecated/alists_unsorted.c
+++ b/mudlib/deprecated/alists_unsorted.c
@@ -11,8 +11,6 @@
    ascending order though. If yours does, use alists_sorted.c instead!
  */
 
-#pragma rtt_checks
-
 #ifndef __ALISTS__
 
 /*
@@ -24,7 +22,7 @@ private varargs void
 assert_alist(mixed * alist, string context = "")
 {
     if (!efun::sizeof(alist) || !efun::pointerp(alist[0]))
-        efun::raise_error(context + "Not an alist.\n");
+        efun::raise_error(context + "Missing key array.\n");
 
     int keynum = efun::sizeof(alist[0]);
     for (int i = efun::sizeof(alist); i-->1;)
@@ -45,6 +43,9 @@ assert_alist(mixed * alist, string context = "")
 varargs mixed
 assoc(mixed key, mixed * keys_or_alist, mixed data_or_fail, mixed fail)
 {
+    if (!efun::pointerp(keys_or_alist))
+        raise_error("Bad argument 2 to assoc().\n");
+
     // case 3: mixed assoc(mixed key, mixed *keys, mixed *data [, mixed fail])
     if (efun::pointerp(data_or_fail))
     {
@@ -136,6 +137,9 @@ insert_alist(mixed key, varargs mixed * args)
 mixed *
 order_alist(mixed * keys, varargs mixed * data)
 {
+    if (!efun::pointerp(keys))
+        raise_error("Bad argument 1 to order_alist().\n");
+
     // whole alist given -> return
     if (!efun::sizeof(data))
     {

--- a/mudlib/deprecated/alists_unsorted.c
+++ b/mudlib/deprecated/alists_unsorted.c
@@ -1,0 +1,160 @@
+/*
+   simul-efun replacement for alists
+   by Coogan@Tubmud & Invisible@Beutelland
+
+   IMPORTANT:
+   This implementation does NOT sort the keys in alists. In the old
+   implementation the keys were ordered by driver-internal criteria
+   which did not guarantee a useful order for the user.
+
+   Some Libs rely on the fact that integer keys happened to be in
+   ascending order though. If yours does, use alists_sorted.c instead!
+ */
+
+#pragma rtt_checks
+
+#ifndef __ALISTS__
+
+/*
+   Helper function used in assoc(), order_alist((), and insert_alist()
+
+   check alist for consistency, raise error if not properly formed
+ */
+private varargs void
+assert_alist(mixed * alist, string context = "")
+{
+    if (!efun::sizeof(alist) || !efun::pointerp(alist[0]))
+        efun::raise_error(context + "Not an alist.\n");
+
+    int keynum = efun::sizeof(alist[0]);
+    for (int i = efun::sizeof(alist); i-->1;)
+    {
+        if (!efun::pointerp(alist[i]) || efun::sizeof(alist[i]) != keynum)
+            efun::raise_error(context + "Type or size mismatch of the data arrays.\n");
+    }
+}
+
+
+/*
+   key or data retrieval
+
+   case 1: int   assoc(mixed key, mixed *keys)
+   case 2: mixed assoc(mixed key, mixed *alist [, mixed fail])
+   case 3: mixed assoc(mixed key, mixed *keys, mixed *data [, mixed fail])
+ */
+varargs mixed
+assoc(mixed key, mixed * keys_or_alist, mixed data_or_fail, mixed fail)
+{
+    // case 3: mixed assoc(mixed key, mixed *keys, mixed *data [, mixed fail])
+    if (efun::pointerp(data_or_fail))
+    {
+        if (efun::sizeof(keys_or_alist) != efun::sizeof(data_or_fail))
+            efun::raise_error("Number of keys and values differ.\n");
+
+        int idx = efun::member(keys_or_alist, key);
+        return idx < 0 ? fail : data_or_fail[idx];
+    }
+
+    // case 2: mixed assoc(mixed key, mixed *alist [, mixed fail])
+    if (efun::sizeof(keys_or_alist) && efun::pointerp(keys_or_alist[0]))
+    {
+        assert_alist(keys_or_alist, "Bad argument 2 to assoc(): ");
+
+        int idx = efun::member(keys_or_alist[0], key);
+        return idx < 0 ? data_or_fail : keys_or_alist[1][idx];
+    }
+
+    // case 1: int assoc(mixed key, mixed *keys)
+    if (data_or_fail)
+        efun::raise_error("Bad number of arguments to assoc().\n");
+
+    return efun::member(keys_or_alist, key);
+}
+
+/*
+   key or data insertion
+
+   case 1: mixed * insert_alist(mixed key, mixed data..., mixed * alist)
+   case 2: int     insert_alist(mixed key, mixed * keys)
+ */
+mixed
+insert_alist(mixed key, varargs mixed * args)
+{
+    if (!efun::sizeof(args))
+        raise_error("Missing argument to insert_alist().\n");
+
+    // case 2: int insert_alist(mixed key, mixed * keys)
+    if (efun::sizeof(args) == 1)
+    {
+        if (!efun::pointerp(args[0])
+                || (efun::sizeof(args[0])
+                    && !efun::intp(args[0][0])
+                    && !efun::stringp(args[0][0])))
+            efun::raise_error("Bad argument 2 to insert_alist().\n");
+
+        int idx = efun::member(args[0], key);
+
+        if (idx >= 0) return idx; // existing key
+
+        // add new key, if key array was given by reference
+        args[0] += ({ key });
+        return efun::sizeof(args[0]) - 1;
+    }
+
+    // case 1: mixed * insert_alist(mixed key, mixed data..., mixed * alist)
+    assert_alist(args[<1],
+            "Bad argument " + efun::sizeof(args) + " to insert_alist(): ");
+
+    mixed * alist = efun::deep_copy(args[<1]);
+
+    int idx = efun::member(alist[0], key);
+    if (idx >= 0)
+    {
+        // existing key
+        for (int i = efun::sizeof(alist); i-->1;)
+        {
+            alist[i][idx] = args[i-1];
+        }
+    }
+    else
+    {
+        // new key
+        alist[0] += ({ key });
+
+        for (int i = efun::sizeof(alist); i-->1;)
+        {
+            alist[i] += ({ args[i-1] });
+        }
+    }
+
+    return alist;
+}
+
+/*
+   for unsorted keys this is a no-op
+ */
+mixed *
+order_alist(mixed * keys, varargs mixed * data)
+{
+    // whole alist given -> return
+    if (!efun::sizeof(data))
+    {
+        assert_alist(keys, "Bad argument 1 to order_alist(): ");
+        return keys;
+    }
+
+    mixed * alist = ({ keys }) + data;
+    assert_alist(alist, "Bad argument(s) to order_alist(): ");
+    return alist;
+}
+
+/*
+   intersect two lists, preserving the order of the first
+ */
+mixed *
+intersect_alist(mixed * list1, mixed * list2)
+{
+    return list1 & list2;
+}
+
+#endif

--- a/mudlib/deprecated/alists_unsorted.c
+++ b/mudlib/deprecated/alists_unsorted.c
@@ -98,7 +98,8 @@ insert_alist(mixed key, varargs mixed * args)
         if (idx >= 0) return idx; // existing key
 
         // add new key, if key array was given by reference
-        args[0] += ({ key });
+        if (referencep(&(args[0])))
+            args[0] += ({ key });
         return efun::sizeof(args[0]) - 1;
     }
 
@@ -128,6 +129,11 @@ insert_alist(mixed key, varargs mixed * args)
         }
     }
 
+    /*
+    // update arg if it was given by reference
+    if (referencep(&(args[<1])))
+        args[<1] = alist;
+     */
     return alist;
 }
 

--- a/mudlib/deprecated/alists_unsorted.c
+++ b/mudlib/deprecated/alists_unsorted.c
@@ -9,6 +9,13 @@
 
    Some Libs rely on the fact that integer keys happened to be in
    ascending order though. If yours does, use alists_sorted.c instead!
+
+   IMPORTANT NOTE on insert_alist():
+   Contrary to the original documentation, the actual efun _never_ updated
+   the key array in-place. This simul-efun checks if the key or value array
+   was passed by reference and does an in-place update in that case.
+   If you need the function to behave _strictly_ as originally implemented,
+   please remove the respective sections (marked as OPTIONAL) below.
  */
 
 #ifndef __ALISTS__
@@ -97,9 +104,11 @@ insert_alist(mixed key, varargs mixed * args)
 
         if (idx >= 0) return idx; // existing key
 
-        // add new key, if key array was given by reference
+        // OPTIONAL: update arg if passed by reference
         if (referencep(&(args[0])))
             args[0] += ({ key });
+        // *******************************************
+        
         return efun::sizeof(args[0]) - 1;
     }
 
@@ -129,11 +138,11 @@ insert_alist(mixed key, varargs mixed * args)
         }
     }
 
-    /*
-    // update arg if it was given by reference
+    // OPTIONAL: update arg if passed by reference
     if (referencep(&(args[<1])))
         args[<1] = alist;
-     */
+    // *******************************************
+
     return alist;
 }
 


### PR DESCRIPTION
Simul-Efuns to provide backwards compatibility with alists by Coogan@Tubmud & myself.

This PR contains two implementations:

- alists_sorted.c
  This implements alists with sorted key arrays. With the old driver implementation the keys were ordered by internal criteria; for integer keys this coincidentally resulted in numerical ordering, which some Libs rely upon.
  As a consequence, keys have to be comparable, which means that only integer and string are supported and all keys in an alist have to be of the same type.

- alists_unsorted.c
  Implements alists without sorting the keys. If the Lib does not rely on ordered key arrays this implementation offers far superior performance for some operations.