### PR TITLE
Fix libxml2 xmlErrorPtr error

### DIFF
--- a/src/pkg-xml2.c
+++ b/src/pkg-xml2.c
@@ -507,6 +507,16 @@ f_xml_generate (svalue_t *sp)
     return sp;
 }
 
+#if LIBXML_VERSION >= 21200
+static void
+xml_pkg_error_handler(void * userData, const xmlError *error)
+{
+    if (error)
+    {
+        errorf("Bad arg 1 to xml_parse(): %s", error->message);
+    }
+}
+#else
 static void
 xml_pkg_error_handler(void * userData, xmlErrorPtr error)
 {
@@ -515,6 +525,7 @@ xml_pkg_error_handler(void * userData, xmlErrorPtr error)
         errorf("Bad arg 1 to xml_parse(): %s", error->message);
     }
 }
+#endif
 
 svalue_t *
 f_xml_parse(svalue_t * sp)


### PR DESCRIPTION
# Problem

When attempting to compile this locally with `enable-use-xml`, I experienced the following compilation error:

```
./mk-patchlevel.sh
3.6.7-3-g4ce74380
gcc -I/usr/include/libxml2  -fwrapv -O2 -g   -Wall -Wparentheses -Wshadow -Wstrict-overflow=2  -DMUD_LIB='"/usr/local/ldmud/lib"' -DBINDIR='"/usr/local/ldmud/bin"' -DERQ_DIR='"/usr/local/ldmud/libexec"'    -c -o lex.o lex.c
gcc -I/usr/include/libxml2  -fwrapv -O2 -g   -Wall -Wparentheses -Wshadow -Wstrict-overflow=2  -DMUD_LIB='"/usr/local/ldmud/lib"' -DBINDIR='"/usr/local/ldmud/bin"' -DERQ_DIR='"/usr/local/ldmud/libexec"'    -c -o main.o main.c
gcc -I/usr/include/libxml2  -fwrapv -O2 -g   -Wall -Wparentheses -Wshadow -Wstrict-overflow=2  -DMUD_LIB='"/usr/local/ldmud/lib"' -DBINDIR='"/usr/local/ldmud/bin"' -DERQ_DIR='"/usr/local/ldmud/libexec"'    -c -o pkg-xml2.o pkg-xml2.c
pkg-xml2.c: In function ‘f_xml_parse’:
pkg-xml2.c:568:37: error: passing argument 2 of ‘xmlSetStructuredErrorFunc’ from incompatible pointer type [-Wincompatible-pointer-types]
  568 |     xmlSetStructuredErrorFunc(NULL, xml_pkg_error_handler);
      |                                     ^~~~~~~~~~~~~~~~~~~~~
      |                                     |
      |                                     void (*)(void *, xmlError *) {aka void (*)(void *, struct _xmlError *)}
In file included from /usr/include/libxml2/libxml/valid.h:15,
                 from /usr/include/libxml2/libxml/parser.h:19,
                 from pkg-xml2.c:18:
/usr/include/libxml2/libxml/xmlerror.h:898:57: note: expected ‘xmlStructuredErrorFunc’ {aka ‘void (*)(void *, const struct _xmlError *)’} but argument is of type ‘void (*)(void *, xmlError *)’ {aka ‘void (*)(void *, struct _xmlError *)’}
  898 |                                  xmlStructuredErrorFunc handler);
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
make: *** [<builtin>: pkg-xml2.o] Error 1
```

# Analysis

This appears to be due to a breaking change with [libxml2 v2.12.0](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.0), specifically under the **Improvements** section:

> error: Make more xmlError structs constant

# Solution

Using Google, I ran into a similar issue with [PostgreSQL](https://www.postgresql.org/message-id/CACpMh%2BDMZVHM%2BiDSyqdcpK8sr7jd_HxxLJRNvGTzcLBE0W07QA%40mail.gmail.com). This solution is a copy-paste of this solution, wherein depending on the `LIBXML_VERSION`, we use the new `const xmlErrorPtr *error` or the legacy `xmlErrorPtr error`.