### PR TITLE
pkg-xml2: support libxml2 v2.12+

### DIFF
--- a/src/pkg-xml2.c
+++ b/src/pkg-xml2.c
@@ -507,8 +507,13 @@ f_xml_generate (svalue_t *sp)
     return sp;
 }
 
+#if LIBXML_VERSION >= 21200
+static void
+xml_pkg_error_handler(void * userData, const xmlError *error)
+#else
 static void
 xml_pkg_error_handler(void * userData, xmlErrorPtr error)
+#endif
 {
     if (error)
     {


### PR DESCRIPTION
The v2.12.0 release of libxml2 changed the definition of the callback used with `xmlSetStructuredErrorFunc()` (ref libxml2 [NEWS](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/NEWS)). This commit adjusts `pkg-xml2.c` to support both the 2.12.0+ definition, as well as the older one.

<details>
<summary>Avoids the following compilation error:</summary>

```
       > gcc -I/nix/store/wwl1jdh5wlnx45vjqa24vapn799d24dv-libxml2-2.13.6-dev/include/libxml2 -I/nix/store/priv4708a19h2rg2z40z2ca6gm5vz3lp-json-c-0.18-dev/include -I/nix/store/priv4708a19h2rg2z40z2ca6gm5vz3lp-json-c-0.18-dev/include/json-c  -fwrapv -O2 -g   -Wall -Wparentheses -Wshadow -Wstrict-overflow=2  -DMUD_LIB='"/nix/store/dj6f7jxxan1ihgxvrqbjr39xj6knjyx0-ldmud-3.6.7/lib"' -DBINDIR='"/nix/store/dj6f7jxxan1ihgxvrqbjr39xj6knjyx0-ldmud-3.6.7/bin"' -DERQ_DIR='"/nix/store/dj6f7jxxan1ihgxvrqbjr39xj6knjyx0-ldmud-3.6.7/libexec"'    -c -o pkg-xml2.o pkg-xml2.c
       > pkg-xml2.c: In function 'f_xml_parse':
       > pkg-xml2.c:568:37: error: passing argument 2 of 'xmlSetStructuredErrorFunc' from incompatible pointer type []
       >   568 |     xmlSetStructuredErrorFunc(NULL, xml_pkg_error_handler);
       >       |                                     ^~~~~~~~~~~~~~~~~~~~~
       >       |                                     |
       >       |                                     void (*)(void *, xmlError *) {aka void (*)(void *, struct _xmlError *)}
       > In file included from /nix/store/wwl1jdh5wlnx45vjqa24vapn799d24dv-libxml2-2.13.6-dev/include/libxml2/libxml/valid.h:16,
       >                  from /nix/store/wwl1jdh5wlnx45vjqa24vapn799d24dv-libxml2-2.13.6-dev/include/libxml2/libxml/parser.h:20,
       >                  from pkg-xml2.c:18:
       > /nix/store/wwl1jdh5wlnx45vjqa24vapn799d24dv-libxml2-2.13.6-dev/include/libxml2/libxml/xmlerror.h:905:57: note: expected 'xmlStructuredErrorFunc' {aka 'void (*)(void *, const struct _xmlError *)'} but argument is of type 'void (*)(void *, xmlError *)' {aka 'void (*)(void *, struct _xmlError *)'}
       >   905 |                                  xmlStructuredErrorFunc handler);
       >       |                                  ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
       > make: *** [<builtin>: pkg-xml2.o] Error 1
```
</details>
