### PR TITLE
Fix inconsistencies in the south section of the lp-245 mudlib.

### DIFF
--- a/mud/lp-245/room/south/sforst42.c
+++ b/mud/lp-245/room/south/sforst42.c
@@ -36,6 +36,6 @@ int east()
 
 int west()
 {
-    this_player()->move_player("west#room/south/sforst44");
+    this_player()->move_player("west#room/south/sforst43");
     return 1;
 }

--- a/mud/lp-245/room/south/sshore25.c
+++ b/mud/lp-245/room/south/sshore25.c
@@ -22,7 +22,7 @@ void long()
     write("You are standing on the shore of Crescent Lake, a beautiful and\n" +
 	  "clear lake. Out in the centre of the lake stands the Isle\n" +
 	  "of the Magi.\n" +
-	  "Trails lead into the forest to the south and west.\n" +
+	  "Trails lead into the forest to the north and east.\n" +
 	  "The shore of Crescent Lake continues northwest and southeast\n");
 }
 

--- a/mud/lp-245/room/south/sshore29.c
+++ b/mud/lp-245/room/south/sshore29.c
@@ -8,7 +8,6 @@ void init()
 {
     add_action("west", "west");
     add_action("east", "east");
-    add_action("southeast", "southeast");
 }
 
 string short()
@@ -21,24 +20,17 @@ void long()
     write("You are standing on the shore of Crescent Lake, a beautiful and\n" +
 	  "clear lake. Out in the centre of the lake stands the Isle\n" +
 	  "of the Magi.\n" +
-	  "A trail leads into the forest to the east.\n" +
-	  "The shore of Crescent Lake continues southeast and west\n");
+	  "The shore of Crescent Lake continues east and west\n");
 }
 
 int east()
 {
-    this_player()->move_player("east#room/south/sforst8");
+    this_player()->move_player("east#room/south/sshore30");
     return 1;
 }
 
 int west()
 {
     this_player()->move_player("west#room/south/sshore28");
-    return 1;
-}
-
-int southeast()
-{
-    this_player()->move_player("southeast#room/south/sshore1");
     return 1;
 }

--- a/mud/lp-245/room/south/sshore30.c
+++ b/mud/lp-245/room/south/sshore30.c
@@ -33,7 +33,7 @@ int east()
 
 int west()
 {
-    this_player()->move_player("west#room/south/sshore28");
+    this_player()->move_player("west#room/south/sshore29");
     return 1;
 }
 


### PR DESCRIPTION
Some rooms have incorrect and thus inconsistent neighbouring rooms so once to move there and move back, you won't be back in the same place. Also some descriptions had conflicting information on exit directtions.