### PR TITLE
feat: add PROXY protocol v1 support for reverse proxies

### DIFF
--- a/src/autoconf/configure.ac
+++ b/src/autoconf/configure.ac
@@ -215,6 +215,7 @@ AC_MY_ARG_ENABLE(filename-spaces,no,,[Allow space characters in filenames])
 AC_MY_ARG_ENABLE(share-variables,no,,[Enable clone initialization from blueprint variable values])
 AC_MY_ARG_ENABLE(keyword-in,no,,[Enable 'in' as a keyword])
 AC_MY_ARG_ENABLE(use-ipv6,no,,[Enables support for IPv6])
+AC_MY_ARG_ENABLE(use-proxy-protocol,no,,[Enables PROXY protocol v1 support for reverse proxies])
 AC_MY_ARG_ENABLE(use-anl,no,,[Enable asynchronous name lookup using C-Ares])
 AC_MY_ARG_ENABLE(use-mccp,no,,[Enables MCCP support])
 AC_MY_ARG_ENABLE(use-mysql,no,,[Enables mySQL support])
@@ -1013,6 +1014,15 @@ else
     fi
     cdef_use_ipv6="#undef"
     enable_use_ipv6=no
+fi
+
+# --- PROXY protocol v1 ---
+
+AC_UPDATE_VAR(enable_use_proxy_protocol)
+if test "x$enable_use_proxy_protocol" = "xyes"; then
+    cdef_use_proxy_protocol="#define"
+else
+    cdef_use_proxy_protocol="#undef"
 fi
 
 # --- Asynchronous Name Lookup ---
@@ -2568,6 +2578,7 @@ AC_SUBST(cdef_filename_spaces)
 AC_SUBST(cdef_share_variables)
 AC_SUBST(cdef_keyword_in)
 AC_SUBST(cdef_use_ipv6)
+AC_SUBST(cdef_use_proxy_protocol)
 AC_SUBST(cdef_use_anl)
 AC_SUBST(cdef_use_mysql)
 AC_SUBST(cdef_use_pgsql)

--- a/src/comm.c
+++ b/src/comm.c
@@ -2748,7 +2748,8 @@ get_message (char *buff, size_t *bufflength)
                             {
                                 char *end = (char *)memchr(
                                     proxy_buf, '\n', n);
-                                if (end) {
+                                if (end && end > proxy_buf
+                                    && *(end - 1) == '\r') {
                                     int hdr_len = (int)(end - proxy_buf) + 1;
                                     char proto[6], src_ip[46], dst_ip[46];
                                     int src_port, dst_port;

--- a/src/comm.c
+++ b/src/comm.c
@@ -2763,33 +2763,50 @@ get_message (char *buff, size_t *bufflength)
                                         proto, src_ip, dst_ip,
                                         &src_port, &dst_port) == 5)
                                     {
+                                        if (strcmp(proto, "TCP4") == 0)
+                                        {
+                                            struct in_addr real4;
+                                            if (inet_aton(src_ip, &real4)) {
 #ifdef USE_IPV6
-                                        struct in6_addr real6;
-                                        struct in_addr  real4;
-                                        if (inet_pton(AF_INET6, src_ip,
-                                                      &real6) == 1) {
-                                            addr.sin6_addr = real6;
-                                            addr.sin6_port =
-                                                htons((unsigned short)src_port);
-                                        } else if (inet_pton(AF_INET, src_ip,
-                                                             &real4) == 1) {
-                                            /* map IPv4 to IPv6-mapped */
-                                            memset(&addr.sin6_addr, 0, 10);
-                                            memset((char*)&addr.sin6_addr+10,
-                                                   0xff, 2);
-                                            memcpy((char*)&addr.sin6_addr+12,
-                                                   &real4, 4);
-                                            addr.sin6_port =
-                                                htons((unsigned short)src_port);
+                                                /* map IPv4 to IPv6-mapped */
+                                                memset(&addr.sin6_addr, 0, 10);
+                                                memset((char*)&addr.sin6_addr+10,
+                                                       0xff, 2);
+                                                memcpy((char*)&addr.sin6_addr+12,
+                                                       &real4, 4);
+                                                addr.sin6_port =
+                                                    htons((unsigned short)src_port);
+#else
+                                                addr.sin_addr = real4;
+                                                addr.sin_port =
+                                                    htons((unsigned short)src_port);
+#endif
+                                            }
+                                        }
+#ifdef USE_IPV6
+                                        else if (strcmp(proto, "TCP6") == 0)
+                                        {
+                                            struct in6_addr real6;
+                                            if (inet_pton(AF_INET6, src_ip,
+                                                          &real6) == 1) {
+                                                addr.sin6_addr = real6;
+                                                addr.sin6_port =
+                                                    htons((unsigned short)src_port);
+                                            }
                                         }
 #else
-                                        struct in_addr real_addr;
-                                        if (inet_aton(src_ip, &real_addr)) {
-                                            addr.sin_addr = real_addr;
-                                            addr.sin_port =
-                                                htons((unsigned short)src_port);
+                                        else if (strcmp(proto, "TCP6") == 0)
+                                        {
+                                            debug_message(
+                                                "%s PROXY protocol: received "
+                                                "TCP6 address %s but driver "
+                                                "was compiled without IPv6 "
+                                                "support, ignoring.\n",
+                                                time_stamp(), src_ip);
                                         }
 #endif
+                                        /* else: unknown proto, drop
+                                         * (invalid header per spec) */
                                     }
                                 }
                             }

--- a/src/comm.c
+++ b/src/comm.c
@@ -2727,9 +2727,76 @@ get_message (char *buff, size_t *bufflength)
                     length = sizeof addr;
                     new_socket = accept(sos[i], (struct sockaddr *)&addr
                                               , &length);
-                    if ((int)new_socket != -1)
+                    if ((int)new_socket != -1) {
+#ifdef SUPPORT_PROXY_PROTOCOL
+                        /* PROXY protocol v1 support.
+                         * If the first bytes on the connection are "PROXY ",
+                         * read the header line and replace the stored client
+                         * address with the real one.
+                         * Format: "PROXY TCP4 <src> <dst> <sport> <dport>\r\n"
+                         * If no PROXY header, proceed normally (backwards
+                         * compatible with direct connections).
+                         */
+                        {
+                            char proxy_buf[108];
+                            int n;
+
+                            n = recv(new_socket, proxy_buf,
+                                     sizeof(proxy_buf) - 1, MSG_PEEK);
+                            if (n >= 6
+                                && memcmp(proxy_buf, "PROXY ", 6) == 0)
+                            {
+                                char *end = (char *)memchr(
+                                    proxy_buf, '\n', n);
+                                if (end) {
+                                    int hdr_len = (int)(end - proxy_buf) + 1;
+                                    char proto[6], src_ip[46], dst_ip[46];
+                                    int src_port, dst_port;
+
+                                    /* consume from the socket */
+                                    recv(new_socket, proxy_buf, hdr_len, 0);
+                                    proxy_buf[hdr_len] = '\0';
+
+                                    if (sscanf(proxy_buf,
+                                        "PROXY %5s %45s %45s %d %d",
+                                        proto, src_ip, dst_ip,
+                                        &src_port, &dst_port) == 5)
+                                    {
+#ifdef USE_IPV6
+                                        struct in6_addr real6;
+                                        struct in_addr  real4;
+                                        if (inet_pton(AF_INET6, src_ip,
+                                                      &real6) == 1) {
+                                            addr.sin6_addr = real6;
+                                            addr.sin6_port =
+                                                htons((unsigned short)src_port);
+                                        } else if (inet_pton(AF_INET, src_ip,
+                                                             &real4) == 1) {
+                                            /* map IPv4 to IPv6-mapped */
+                                            memset(&addr.sin6_addr, 0, 10);
+                                            memset((char*)&addr.sin6_addr+10,
+                                                   0xff, 2);
+                                            memcpy((char*)&addr.sin6_addr+12,
+                                                   &real4, 4);
+                                            addr.sin6_port =
+                                                htons((unsigned short)src_port);
+                                        }
+#else
+                                        struct in_addr real_addr;
+                                        if (inet_aton(src_ip, &real_addr)) {
+                                            addr.sin_addr = real_addr;
+                                            addr.sin_port =
+                                                htons((unsigned short)src_port);
+                                        }
+#endif
+                                    }
+                                }
+                            }
+                        }
+#endif /* SUPPORT_PROXY_PROTOCOL */
                         new_player( NULL, new_socket, &addr, (size_t)length
                                   , port_numbers[i].port);
+                    }
                     else if ((int)new_socket == -1
                       && errno != EWOULDBLOCK && errno != EINTR
                       && errno != EAGAIN && errno != EPROTO )

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -208,6 +208,13 @@
  */
 @cdef_use_ipv6@ USE_IPV6
 
+/* Define this if you want PROXY protocol v1 support. When enabled, the
+ * driver auto-detects PROXY protocol headers on new connections (as sent
+ * by HAProxy, Traefik, etc.) and uses the real client IP instead of the
+ * proxy's IP. Connections without a PROXY header work normally.
+ */
+@cdef_use_proxy_protocol@ SUPPORT_PROXY_PROTOCOL
+
 /* Define this if you want asynchronous name lookup using libanl
  * instead of using the ERQ.
  */

--- a/src/main.c
+++ b/src/main.c
@@ -2009,6 +2009,9 @@ options (void)
 #ifdef USE_IPV6
                               , "IPv6 supported\n"
 #endif
+#ifdef SUPPORT_PROXY_PROTOCOL
+                              , "PROXY protocol v1 supported\n"
+#endif
 #ifdef USE_MCCP
                               , "MCCP supported\n"
 #endif


### PR DESCRIPTION
## Summary

Adds optional support for [PROXY protocol v1](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt), the widely adopted standard by HAProxy for preserving real client IPs through TCP reverse proxies. A good overview of the protocol: [Exploring the PROXY Protocol](https://seriousben.com/posts/2020-02-exploring-the-proxy-protocol/).

When enabled, the driver peeks at the first bytes of each new connection after `accept()`. If they match a PROXY v1 header (`PROXY TCP4/TCP6 <src> <dst> <sport> <dport>\r\n`), the real client IP and port are extracted and used instead of the proxy's address. Connections without a PROXY header proceed normally.

This allows MUDs running behind reverse proxies (Traefik, HAProxy, nginx, AWS ELB, etc.) to see real client IPs in `query_ip_number()`, `query_ip_name()`, `interactive_info(II_IP_ADDRESS)`, `interactive_info(II_IP_NAME)`, and all related efuns — which is increasingly common in containerized/Docker deployments.

## Configuration

Disabled by default. Enable at configure time:

```sh
./configure --enable-use-proxy-protocol
```

When enabled, `SUPPORT_PROXY_PROTOCOL` is defined in `config.h` and the feature appears in `--options` output as "PROXY protocol v1 supported".

## Changed files

- `src/comm.c` — PROXY v1 header parsing after `accept()`, guarded by `#ifdef SUPPORT_PROXY_PROTOCOL`. Supports both `USE_IPV6` and non-IPv6 builds (with IPv4-to-IPv6 mapping).
- `src/config.h.in` — new `SUPPORT_PROXY_PROTOCOL` define placeholder.
- `src/autoconf/configure.ac` — new `--enable-use-proxy-protocol` option.
- `src/main.c` — display "PROXY protocol v1 supported" in `--options` output.

## Compatibility

- **Backwards compatible**: connections without a PROXY header work exactly as before.
- **No mudlib changes required**: `query_ip_number()`, `query_ip_name()`, and `interactive_info()` transparently return the real client IP.
- **No new dependencies**: uses only `recv()` with `MSG_PEEK`, `memcmp`, `sscanf`, `inet_aton`/`inet_pton` — all already available.

## Testing

We have been running this patch in production at [maldorne.org](https://maldorne.org) behind Traefik with PROXY protocol v1. Tested with both direct telnet connections (no PROXY header) and proxied connections (with PROXY header). Real client IPs appear correctly in login logs and `query_ip_number()` results.

We have also implemented the same approach (adapted to the MudOS codebase) in our own [MudOS fork branches](https://github.com/maldorne/mudos), where it has been tested successfully in production with four different MUDs.

To test without a reverse proxy, compile with `--enable-use-proxy-protocol` and send a PROXY header manually with `printf` + `nc`:

```sh
{ printf "PROXY TCP4 198.51.100.42 203.0.113.10 49152 5000\r\n"; cat; } | nc localhost 5000
```

The driver should accept the connection normally. `query_ip_number()` on the connected user should return `198.51.100.42` instead of the local address. Without the `printf` line, the same `nc` command should also work (backwards compatibility).

## Context

No MUD driver currently supports PROXY protocol ([FluffOS issue #505](https://github.com/fluffos/fluffos/issues/505) requested it in 2019 and it was closed without implementation). This is a common need for MUDs running in Docker behind reverse proxies, where all connections appear to come from the proxy's internal IP.

Blog post with full details: [Implementing PROXY protocol in MUD drivers](https://maldorne.org/2026/04/14/implementing-proxy-protocol-in-mud-drivers/)