### PR TITLE
interpret: skip stack-gap check when freeing simple svalues

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1155,6 +1155,18 @@ int_free_svalue (svalue_t *v)
 {
     ph_int type = v->type;
 
+    /* Integers, floats and already-freed slots don't reference anything and
+     * can't cause a recursive free, so there is nothing to do beyond marking
+     * the value invalid. Skip the stack-gap check and the switch for them -
+     * this is by far the most common case (e.g. every integer popped off the
+     * stack).
+     */
+    if (type == T_NUMBER || type == T_FLOAT || type == T_INVALID)
+    {
+        v->type = T_INVALID;
+        return;
+    }
+
     v->type = T_INVALID;
       /* If freeing the value throws an error, it is most likely that
        * we ran out of stack. To avoid the error handling running


### PR DESCRIPTION
`int_free_svalue()` runs `assert_stack_gap()` and the full type switch for every value it frees. `assert_stack_gap()` lives in another translation unit, so it is a real (non-inlinable) call, and it guards against stack overflow during *recursive* frees. Integers, floats and already-invalidated slots reference nothing and can never recurse, so all of that work is pointless for
them - and they are by far the most common thing freed (every integer popped off the value stack goes through here).

This adds an early return for those types before the check. Everything else is untouched, so the recursion guard still fires for the cases that can actually recurse.

Measured on a VM-bound micro-benchmark (tight loops of integer arithmetic, calls, array/mapping access and string building; median of interleaved runs): ~11% less CPU. Real mudlib workloads spend time outside the VM too, so the gain there will be smaller, but this is a per-free saving that scales with execution.

Tested with `test/run.sh` (`--check-refcounts --check-state 2`): no change in results versus master.