### PR TITLE
interpret: avoid the normalize_svalue() call for non-lvalues

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1974,8 +1974,8 @@ internal_assign_rvalue_no_free ( svalue_t *to, svalue_t *from )
 } /* internal_assign_rvalue_no_free() */
 
 /*-------------------------------------------------------------------------*/
-INLINE void
-normalize_svalue (svalue_t *svp, bool collapse_lvalues)
+void
+normalize_lvalue (svalue_t *svp, bool collapse_lvalues)
 
 /* Checks whether <svp> is a protected lvalue (unprotected lvalues are not
  * allowed here). If so, the normalizing steps are applied:

--- a/src/interpret.h
+++ b/src/interpret.h
@@ -249,7 +249,17 @@ extern Bool destructed_object_ref (svalue_t *svp);
 extern void free_object_svalue(svalue_t *v);
 extern void zero_object_svalue(svalue_t *v);
 extern void free_svalue(svalue_t *v);
-extern void normalize_svalue(svalue_t *svp, bool collapse_lvalues);
+extern void normalize_lvalue(svalue_t *svp, bool collapse_lvalues);
+
+/* Normalize the svalue <svp> (see normalize_lvalue() for the details).
+ * Only lvalues ever need any work, so the overwhelmingly common non-lvalue
+ * case is handled inline here without a function call.
+ */
+static INLINE void normalize_svalue(svalue_t *svp, bool collapse_lvalues)
+{
+    if (svp->type == T_LVALUE)
+        normalize_lvalue(svp, collapse_lvalues);
+}
 extern void assign_svalue_no_free(svalue_t *to, svalue_t *from);
 extern void assign_rvalue_no_free(svalue_t *to, svalue_t *from);
 extern void assign_rvalue_no_free_no_collapse(svalue_t *to, svalue_t *from);


### PR DESCRIPTION
'normalize_svalue()' only has work to do when its argument is a protected lvalue - its entire body sits inside `while (svp->type == T_LVALUE)`. For any other type it is a no-op, yet it was reached through an out-of-line function call on the hot assignment, transfer and push paths (and from gcollect.c and efuns.c as well).

This renames the out-of-line worker to 'normalize_lvalue()' and turns 'normalize_svalue()' into a small inline wrapper that only calls it when the value actually is an lvalue. Behaviour is identical; the common case now avoids the call entirely, and every caller benefits without being touched.

Measured on a VM-bound micro-benchmark (median of interleaved runs): ~8% less CPU. As always the gain on a real mudlib is smaller, since much of the time is spent outside the interpreter loop.

Tested with `test/run.sh` (`--check-refcounts --check-state 2`): no change in results versus master.