### PR TITLE
interpret: avoid redundant trace object assignments

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -10121,7 +10121,8 @@ again:
         previous_pc[last] = pc-1;
         stack_size[last] = sp - fp - csp->num_local_variables;
         abs_stack_size[last] = sp - VALUE_STACK;
-        assign_current_object(previous_objects + last, "TRACE_CODE");
+        if (!is_current_object(previous_objects[last]))
+            assign_current_object(previous_objects + last, "TRACE_CODE");
         previous_programs[last] = current_prog;
 #   endif  /* ifdef TRACE_CODE */
 


### PR DESCRIPTION
- Skip the TRACE_CODE ring object assignment when the slot already holds the current object.
- Avoid redundant refcount churn on the interpreter hot path while preserving trace history.

- Local bytecode-heavy benchmark: 2.67s to 2.18s user CPU, about 18% less.

Tested by running  ./run.sh t-operators.c t-language t-lwobject t-trace-coroutine.c t-gc
