### PR TITLE
xalloc: define NVALGRIND before including the allocator sources

### DIFF
--- a/src/xalloc.c
+++ b/src/xalloc.c
@@ -338,6 +338,10 @@ mdb_log_sbrk (p_int size)
  * otherwise we are in trouble...
  */
 
+#ifndef SUPPORT_VALGRIND
+#  define NVALGRIND
+#endif
+
 #if defined(MALLOC_smalloc)
 #  define NVALGRIND
 #  include "valgrind/memcheck.h"
@@ -351,10 +355,6 @@ mdb_log_sbrk (p_int size)
 #  include "sysmalloc.c"
 #else
 #  error "No allocator specified."
-#endif
-
-#ifndef SUPPORT_VALGRIND
-#  define NVALGRIND
 #endif
 
 #ifndef GRANULARITY

--- a/src/xalloc.c
+++ b/src/xalloc.c
@@ -348,6 +348,19 @@ mdb_log_sbrk (p_int size)
 #  include "smalloc.c"
 #elif defined(MALLOC_slaballoc)
 #  include "valgrind/memcheck.h"
+#  ifdef NVALGRIND
+     /* The disabled client request macros expand to their bare default
+      * value, which -Wunused-value objects to when they are used as
+      * statements. Replace the ones the allocator uses with real no-ops
+      * that still evaluate their arguments.
+      */
+#    undef VALGRIND_MAKE_MEM_NOACCESS
+#    undef VALGRIND_MAKE_MEM_UNDEFINED
+#    undef VALGRIND_MAKE_MEM_DEFINED
+#    define VALGRIND_MAKE_MEM_NOACCESS(_qzz_addr,_qzz_len)  ((void)(_qzz_addr), (void)(_qzz_len))
+#    define VALGRIND_MAKE_MEM_UNDEFINED(_qzz_addr,_qzz_len) ((void)(_qzz_addr), (void)(_qzz_len))
+#    define VALGRIND_MAKE_MEM_DEFINED(_qzz_addr,_qzz_len)   ((void)(_qzz_addr), (void)(_qzz_len))
+#  endif
 #  include "slaballoc.c"
 #elif defined(MALLOC_sysmalloc)
 #  define NVALGRIND


### PR DESCRIPTION
The bundled valgrind headers decide at include time whether the client request macros expand to real magic sequences or to no-ops, based on NVALGRIND. The '#ifndef SUPPORT_VALGRIND: #define NVALGRIND' guard sat below the allocator include chain, i.e. after valgrind/memcheck.h and the allocator source were already compiled. The smalloc and sysmalloc branches define NVALGRIND themselves, but for slaballoc the guard came too late: every slaballoc build carried live valgrind instrumentation in all allocator paths, regardless of --enable-valgrind.

On a default (non-valgrind) build this shrinks add_to_free_list from 5898 to 718 bytes of code and speeds up a save_object/restore_object heavy benchmark by ~18%.