### PR TITLE
config: disable the address-ordered large-block freelists by default

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -644,10 +644,13 @@
 
 /* Order malloc large block freelists by address.
  * Supported by: MALLOC_smalloc, MALLOC_slaballoc.
- * TODO: Remove if it doesn't help with the fragmentation, as it uses up
- * TODO:: a small, but measurable amount of time in the allocator.
+ * The ordered insertion walks the list of same-sized free blocks linearly,
+ * which degenerates to O(n) per free on long-running heaps with many free
+ * blocks of one size, and profiles show it can dominate the allocator's
+ * runtime cost. No corresponding reduction of memory fragmentation could
+ * be measured, so it is disabled by default.
  */
-#define MALLOC_ORDER_LARGE_FREELISTS
+#undef MALLOC_ORDER_LARGE_FREELISTS
 
 /* Order slaballoc partial-slab freelists by number of free blocks.
  * Supported by: MALLOC_slaballoc.


### PR DESCRIPTION
With MALLOC_ORDER_LARGE_FREELISTS the allocator keeps the list of same-sized free large blocks sorted by address, walking the list linearly on every insertion. On long-running muds many free blocks of the same size accumulate (the walk is what the option's comment called 'a small, but measurable amount of time'), and the insertion degrades to O(n) per free. A profile of a production mud showed about a quarter of the driver's total CPU time in this walk; a synthetic aged-heap benchmark runs 4x faster without the ordering.

The intended benefit (less fragmentation) did not show up in measurements: a seeded soak test with mixed lifetimes, load spikes and drifting allocation sizes produced a byte-identical heap footprint with and without the ordering. Best-fit allocation and the coalescing of adjacent free blocks are independent of the list order.

Kept the code, but turn the ordering off by default.