### PR TITLE
adjust doc of efuns save_object and restore_object to reflect reality

### DIFF
--- a/doc/efun.de/restore_object.de
+++ b/doc/efun.de/restore_object.de
@@ -10,11 +10,11 @@ BESCHREIBUNG
         mit der typischen Zeile "#x:y" beginnen. Strings, die von der Efun
         save_object() erzeugt wurden, beginnen so.
 
-        Wenn Variablen aus einer Datei geladen werden, kann <name> mit .c
-        enden. Diese Dateiendung wird vom Treiber entfernt. Das Masterobjekt
-        fuegt vermutlich dem Dateinamen ein .o hinzu. Die Gueltigkeit des
-        Dateinamens wird mit der Funktion check_valid_path() automatisch
-        ueberprueft.
+        Wenn Variablen aus einer Datei geladen werden wird der Lesezugriff
+        ueber einen Aufruf der valid_read() im Masterobjekt ueberprueft. Dort
+        kann der Dateiname noch veraendert werden. Vor dem Lesen wird eine
+        eventuell noch vorhandene Endung ".c" im Dateinamen entfernt. Weiters
+        wird die feste Endung ".o" angefuegt.
 
         Die Funktion gibt 1 zurueck, wenn die Variablen erfolgreich geladen
         wurden und 0, wenn es nichts zu laden gab.
@@ -22,7 +22,7 @@ BESCHREIBUNG
         Variablen mit dem Typenvermerk nosave werden nicht geladen, zum
         Beispiel nosave int xxx;
 
-        Clousers aus Lfuns, Variablne und simul_efuns werden nur geladen,
+        Closures aus Lfuns, Variablen und simul_efuns werden nur geladen,
         wenn sie gefunden werden. Falls nicht, werden sie mit dem Wert '0'
         geladen.
 
@@ -43,7 +43,7 @@ GESCHICHTE
             indem ein neues Format fuer das Savefile verwendet wird.
         LDMud 3.5.0 unterstuetzt das Einlesen von Formatversion 2 mit hoeherer
             Praezision der Gleitkommazahlen und Formatversion 3 um
-	    lvalue-Referenzen einzulesen.
+            lvalue-Referenzen einzulesen.
 
 SIEHE AUCH
         save_object(E), restore_value(E), valid_read(M)

--- a/doc/efun.de/save_object.de
+++ b/doc/efun.de/save_object.de
@@ -15,7 +15,8 @@ BESCHREIBUNG
 
         Das Schreiben der Datei geschieht 'atomar', d.h. die Datei wird zuerst
         als "<name>.o.tmp" geschrieben und erst nach dem Abschluss des
-        Schreibvorgangs auf "<name>.o" umbenannt.
+        Schreibvorgangs auf "<name>.o" umbenannt. Sollte die Datei
+        "<name>.o.tmp" bereits exitieren wird sie dabei überschrieben!
 
         Die Efun save_object() liefert 0, wenn die Speicherdatei erfolgreich
         erstellt wurde, sonst eine Zahl ungleich 0, wenn ein nicht

--- a/doc/efun.de/save_object.de
+++ b/doc/efun.de/save_object.de
@@ -6,19 +6,28 @@ BESCHREIBUNG
         Codiert die speicherbaren Variablen des aktuellen Objekts in einen
         String.
 
-        In der ersten Form wir der String in die Datei <name> geschrieben. Eine
-        Endung ".c" in <name> wird entfernt, dafuer kann eine Endung ".o"
-        durch das Masterobjekt angefuegt werden, waehrend der Ueberpruefung
-        durch valid_read(). Die Efun save_object() liefert 0, wenn die
-        Speicherdatei erfolgreich erstellt wurde, sonst eine Zahl ungleich 0,
-        wenn ein nicht schwerwiegendee Fehler aufgetreten ist (die Datei
-        konnte nicht geschrieben werden oder das aktuelle Objekt wurde
-        inzwischen zerstoert).
+        In der ersten Form wir der String in die Datei <name> geschrieben.
+        Der Schreibzugriff wird ueber einen Aufruf von valid_write() im
+        Masterobjekt ueberprueft. Dort kann der Dateiname noch veraendert
+        werden. Vor dem Schreiben wird eine eventuell noch vorhandene Endung
+        ".c" im Dateinamenn entfernt. Weiters wird die feste Endung ".o"
+        angefuegt.
+
+        Das Schreiben der Datei geschieht 'atomar', d.h. die Datei wird zuerst
+        als "<name>.o.tmp" geschrieben und erst nach dem Abschluss des
+        Schreibvorgangs auf "<name>.o" umbenannt.
+
+        Die Efun save_object() liefert 0, wenn die Speicherdatei erfolgreich
+        erstellt wurde, sonst eine Zahl ungleich 0, wenn ein nicht
+        schwerwiegender Fehler aufgetreten ist (die Datei konnte nicht
+        geschrieben werden oder das aktuelle Objekt wurde inzwischen
+        zerstoert).
 
         In der zweiten Form wird der String direkt zurueck gegeben. Wenn das
-        Objekt zerstoert wurde, wird 0 zurueck gegeben. In beiden Faellen kann
-        durch das optionale Argument <format> das Format der Speicherdatei
-        angegeben werden:
+        Objekt zerstoert wurde, wird 0 zurueck gegeben.
+
+        In beiden Faellen kann durch das optionale Argument <format> das
+        Format der Speicherdatei angegeben werden:
 
             -1: das normale Format des Treibers (Standard)
              0: das Originalformat nach Amylaar's LPMud und LDMud <=3.2.8
@@ -27,8 +36,8 @@ BESCHREIBUNG
              2: LDMUd >= 3.5.0: Gleitkommazahlen werden in einem neuen Format
                 geschrieben, welches kompakter ist die Gleitkommazahlen aus
                 3.5.x verlustfrei speichern kann.
-	     3: LDMud >= 3.5.0: kann zusaetzlich lvalue-Referenzen speichern
-	        (ohne werden stattdessen einfache rvalues gespeichert)
+             3: LDMud >= 3.5.0: kann zusaetzlich lvalue-Referenzen speichern
+                (ohne werden stattdessen einfache rvalues gespeichert)
 
         Es wird empfohlen, die Angabe des Formats wegzulassen oder in Version
         2 (oder hoeher) zu speichern.

--- a/doc/efun/restore_object
+++ b/doc/efun/restore_object
@@ -10,10 +10,10 @@ DESCRIPTION
         with the typical line "#x:y" as it is created by the save_object()
         efun.
 
-        When restoring from a file, the name may end in ".c" which is stripped
-        off by the parser. The master object will probably append a .o to the
-        <name>. The validity of the filename is checked with a call to
-        check_valid_path().
+        When restoring from a file, read access will be checked by calling
+        valid_read() in the master object. The filename may be changed there.
+        Before the actual read, a suffix ".c" will be stripped from the name
+        if present. Furthermore the suffix ".o" is added.
 
         Return 1 on success, 0 if there was nothing to restore.
 

--- a/doc/efun/save_object
+++ b/doc/efun/save_object
@@ -13,7 +13,8 @@ DESCRIPTION
 
         The write will be performed in an 'atomic' way, i.e. the file will
         be written as "<name>.o.tmp" first, and only if that succeeds it will
-        be ranamed to "<name>.o".
+        be ranamed to "<name>.o". If "<name>.o.tmp" happens to exist, it is
+        overwritten!
 
         The efun save_object() returns 0 if the save file could be written
         successfuly, otherwise it returns a non-zero value if a non-fatal

--- a/doc/efun/save_object
+++ b/doc/efun/save_object
@@ -5,12 +5,20 @@ SYNOPSIS
 DESCRIPTION
         Encode the saveable variables of the current object into a string.
 
-        In the first form, the string is written to the file <name>.
-        A suffix ".c" will be stripped from the name, the suffix ".o"
-        may be added by the master object during the check in
-        valid_read(). Result is 0 if the save file could be created,
-        and non-zero on a non-fatal error (file could not be written,
-        or current object is destructed).
+        In the first form, the string is written to the file <name>. The write
+        access will be checked by calling valid_write() in the master object.
+        The filename may be changed there. Before the actual write, a suffix
+        ".c" will be stripped from the name if present. Furthermore the suffix
+        ".o" is added.
+
+        The write will be performed in an 'atomic' way, i.e. the file will
+        be written as "<name>.o.tmp" first, and only if that succeeds it will
+        be ranamed to "<name>.o".
+
+        The efun save_object() returns 0 if the save file could be written
+        successfuly, otherwise it returns a non-zero value if a non-fatal
+        error occured (the file could not be written or the current object
+        was destructed).
 
         In the second form the string is returned directly. If the
         object is destructed, the result is 0.
@@ -24,8 +32,8 @@ DESCRIPTION
                  can be saved.
             2: LDMud >= 3.5.0: floats are stored in a different way, which is
                  more compact and can store the new float losslessly.
-	    3: LDMud >= 3.5.0: can also save lvalues references (without it,
-	         the plain rvalue will be saved).
+            3: LDMud >= 3.5.0: can also save lvalues references (without it,
+                 the plain rvalue will be saved).
 
         It is recommended to use version 3 or higher.
 


### PR DESCRIPTION
The documentation of save_object() and restore_object() wrongly stated that the filename suffix can be changed, when in reality it is hardcoded to ".o".

Update docs to reflect the actual driver code, and also mention that save_object() writes an intermediate ".tmp" file (overwriting that file if it happens to exist).