### PR TITLE
object: restore mappings incrementally instead of pre-scanning

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -8324,59 +8324,125 @@ restore_mapping (svalue_t *svp, char **str)
 /* Restore a mapping from the text starting at *<str> (which points
  * just after the leading '([') and store it into *<svp>.
  * Return TRUE if the restore was successful, FALSE else (*<svp> is
- * set to const0 in that case).
+ * set to const0 resp. left with the partially restored mapping in
+ * that case).
  * On a successful return, *<str> is set to point after the mapping
  * restored.
  *
- * TODO: this function assumes that num_values and num_entries of mappings
- * TODO::are 'int'. Should be changed to p_int.
+ * Only the first entry is scanned ahead (to determine the width of
+ * the mapping); after that the entries are restored incrementally
+ * until the closing ']' is found. This way the mapping text - and
+ * the text of all nested containers - is parsed only once instead of
+ * once per nesting level.
  */
 
 {
     mapping_t *z;
     svalue_t key, *data;
-    int i;
-    struct rms_parameters tmp_par;
-    int siz;
+    p_int i;
+    p_int width;
+    char *pt = *str;
 
-    /* Determine the size and width of the mapping */
+    /* Empty mapping: "])" */
 
-    tmp_par.str = *str;
-    siz = restore_map_size(&tmp_par);
-    if (siz < 0)
+    if (pt[0] == ']')
     {
-        *svp = const0;
-        return MY_FALSE;
+        if (pt[1] != ')')
+        {
+            *svp = const0;
+            return MY_FALSE;
+        }
+        width = 1;
+        pt += 2;
     }
 
-    if (max_mapping_size && siz * (1+tmp_par.num_values) > (p_int)max_mapping_size)
+    /* Empty mapping with explicit width: ":<width>])" */
+
+    else if (pt[0] == ':')
     {
-        *svp = const0;
-        errorf("Illegal mapping size: %ld elements (%d x %d).\n"
-             , (long)siz * (1+tmp_par.num_values)
-             , siz
-             , 1+tmp_par.num_values );
-        return MY_FALSE;
+        width = atoi(pt+1);
+        pt = strchr(pt+1, ']');
+        if (!pt || pt[1] != ')' || width < 0)
+        {
+            *svp = const0;
+            return MY_FALSE;
+        }
+        pt += 2;
+    }
+    else
+        pt = NULL; /* There are entries to restore. */
+
+    if (pt)
+    {
+        z = allocate_mapping(0, width);
+        if (!z)
+        {
+            *svp = const0;
+            errorf("(restore) Out of memory: mapping[0, %ld]\n"
+                 , (long)width);
+            return MY_FALSE;
+        }
+
+        svp->type = T_MAPPING;
+        svp->u.map = z;
+        *str = pt;
+        return MY_TRUE;
     }
 
-    /* Allocate the mapping */
-    z = allocate_mapping(siz, tmp_par.num_values);
+    /* Determine the width of the mapping by scanning the first entry:
+     * skip the key, then count the ':'/';' separated values up to the
+     * ',' ending the entry.
+     */
+    {
+        char *tmp = *str;
+
+        if (!skip_element(&tmp))
+        {
+            *svp = const0;
+            return MY_FALSE;
+        }
+
+        width = 0;
+        if (*tmp == ':')
+        {
+            do
+            {
+                width++;
+                tmp++;
+                if (!skip_element(&tmp))
+                {
+                    *svp = const0;
+                    return MY_FALSE;
+                }
+            } while (*tmp == ';');
+        }
+
+        if (*tmp != ',')
+        {
+            *svp = const0;
+            return MY_FALSE;
+        }
+    }
+
+    /* Allocate the mapping. It grows as the entries are restored. */
+
+    z = allocate_mapping(0, width);
 
     if (!z)
     {
         *svp = const0;
-        errorf("(restore) Out of memory: mapping[%d, %d]\n"
-             , siz, tmp_par.num_values);
+        errorf("(restore) Out of memory: mapping[0, %ld]\n"
+             , (long)width);
         return MY_FALSE;
     }
 
     svp->type = T_MAPPING;
     svp->u.map = z;
 
-    /* Loop through size and width, restoring the values */
-    while (--siz >= 0)
+    /* Restore the entries until the closing '])' is found. */
+    while (MY_TRUE)
     {
-        i = tmp_par.num_values;
+        i = width;
         key.type = T_NUMBER;
         if (!restore_svalue(&key, str, (char)(i ? ':' : ',') ))
         {
@@ -8400,9 +8466,26 @@ restore_mapping (svalue_t *svp, char **str)
             if (!restore_svalue(data++, str, (char)(i ? ';' : ',') ))
                 return MY_FALSE;
         }
+
+        if (max_mapping_size
+         && z->num_entries * (1+width) > (p_int)max_mapping_size)
+        {
+            errorf("Illegal mapping size: %ld elements (%ld x %ld).\n"
+                 , (long)z->num_entries * (1+width)
+                 , (long)z->num_entries
+                 , (long)(1+width) );
+            return MY_FALSE;
+        }
+
+        pt = *str;
+        if (pt[0] == ']')
+        {
+            if (pt[1] != ')')
+                return MY_FALSE;
+            *str = pt + 2;
+            return MY_TRUE;
+        }
     }
-    *str = tmp_par.str;
-    return MY_TRUE;
 } /* restore_mapping() */
 
 /*-------------------------------------------------------------------------*/

--- a/src/object.c
+++ b/src/object.c
@@ -10636,10 +10636,17 @@ static int nesting = 0;  /* Used to detect recursive calls */
              * not found in the shared string table or in the object.
              * That means we can eventually discard this line, but first
              * we have to parse it in case it contains the definition
-             * of a shared array some other variable might use.
-             *
-             * Therefore we create a dummy variable and initialize
-             * it to svalue-int, so that it can be freed without remorse.
+             * of a shared value some other variable might use. Shared
+             * value definitions and references are written as '<id>',
+             * so a line without any '<' character can't affect them
+             * and is skipped without parsing.
+             */
+
+            if (strchr(space+1, '<') == NULL)
+                break; /* Leaves v == NULL: skip the line. */
+
+            /* Create a dummy variable and initialize it to svalue-int,
+             * so that it can be freed without remorse.
              */
 
             {
@@ -10669,6 +10676,21 @@ static int nesting = 0;  /* Used to detect recursive calls */
             }
 
         } while (MY_FALSE);
+
+        /* Skip the line of an unknown variable whose value can't
+         * contain shared value definitions.
+         */
+        if (v == NULL)
+        {
+            if (!file)
+            {
+                char *nl = strchr(space+1, '\n');
+                if (!nl)
+                    break;
+                cur = nl+1;
+            }
+            continue;
+        }
 
         /* Get rid of the old value in v */
 

--- a/test/t-restore.c
+++ b/test/t-restore.c
@@ -40,6 +40,11 @@ void run_test()
     msg("\nRunning restore tests:\n"
           "----------------------\n");
 
+    /* Fail-safe: if an uncaught error aborts run_test(), still
+     * shut down (as failure) instead of hanging.
+     */
+    call_out(#'shutdown, 0, 1);
+
     /* --- Round trip through save_object()/restore_object() --- */
 
     m = ([ "outer": ([ "inner": ({ 1, 2, ({ 3, "four" }) }),
@@ -141,6 +146,11 @@ void run_test()
           restore_object("#1:0\nzzz_gone ([\"p\":1,])\na <1>=({4,})\nb <1>\n") == 1
           && a == b && deep_eq(a, ({4})));
 
+    reset_vars();
+    check("restore: malformed value on unknown variable line is skipped",
+          restore_object("#1:0\nzzz_gone ([\"broken\":1\nx 3\n") == 1
+          && x == 3);
+
     /* --- restore_value() uses the same mapping parser --- */
 
     check("restore_value: nested mapping round trip",
@@ -163,6 +173,8 @@ void run_test()
     reset_vars();
     check("restore: unterminated mapping on known variable throws",
           catch(restore_object("#1:0\nm ([\"a\":1,")) != 0);
+
+    remove_call_out(#'shutdown);
 
     if (errors)
         shutdown(1);

--- a/test/t-restore.c
+++ b/test/t-restore.c
@@ -1,0 +1,177 @@
+#include "/inc/base.inc"
+#include "/inc/deep_eq.inc"
+
+/* Tests for restore_object()/restore_value() mapping and shared-value
+ * handling: nested mappings of various widths, the empty-mapping forms,
+ * duplicate keys, shared values (also those defined on lines of unknown
+ * variables) and lines for variables that don't exist anymore.
+ */
+
+mapping m;
+mixed a;
+mixed b;
+int x;
+
+nosave int errors;
+
+void reset_vars()
+{
+    m = 0;
+    a = 0;
+    b = 0;
+    x = 0;
+}
+
+void check(string name, int ok)
+{
+    if (ok)
+        msg("Success: %s\n", name);
+    else
+    {
+        msg("FAILURE: %s\n", name);
+        errors++;
+    }
+}
+
+void run_test()
+{
+    string s;
+
+    msg("\nRunning restore tests:\n"
+          "----------------------\n");
+
+    /* --- Round trip through save_object()/restore_object() --- */
+
+    m = ([ "outer": ([ "inner": ({ 1, 2, ({ 3, "four" }) }),
+                       "wide": 42 ]),
+           "str": "hello \"quoted\" and \\ backslash\n",
+           "num": -17,
+           "flt": 3.25 ]);
+    a = ([ "k1": 1; "one", "k2": 2; "two" ]);   /* width 2 */
+    b = ([ "solo1", "solo2" ]);                 /* width 0 */
+    x = 4711;
+
+    s = save_object();
+    reset_vars();
+    check("save_object() returned a string", stringp(s) && sizeof(s) > 0);
+
+    check("restore_object(string) round trip", restore_object(s) == 1);
+    check("round trip: nested mapping",
+          deep_eq(m, ([ "outer": ([ "inner": ({ 1, 2, ({ 3, "four" }) }),
+                                    "wide": 42 ]),
+                        "str": "hello \"quoted\" and \\ backslash\n",
+                        "num": -17,
+                        "flt": 3.25 ])));
+    check("round trip: width 2 mapping",
+          deep_eq(a, ([ "k1": 1; "one", "k2": 2; "two" ])));
+    check("round trip: width 0 mapping",
+          deep_eq(b, ([ "solo1", "solo2" ])));
+    check("round trip: int variable", x == 4711);
+
+    /* --- Explicit restore strings: empty mapping forms --- */
+
+    reset_vars();
+    check("restore: empty mapping",
+          restore_object("#1:0\nm ([])\nx 42\n") == 1
+          && deep_eq(m, ([])) && x == 42);
+
+    reset_vars();
+    check("restore: empty mapping with explicit width",
+          restore_object("#1:0\nm ([:5])\n") == 1
+          && mappingp(m) && sizeof(m) == 0 && widthof(m) == 5);
+
+    /* --- Explicit restore strings: nesting and content --- */
+
+    reset_vars();
+    check("restore: deeply nested mapping",
+          restore_object("#1:0\nm ([\"l1\":([\"l2\":([\"l3\":({1,2,3,}),]),]),])\n") == 1
+          && deep_eq(m, ([ "l1": ([ "l2": ([ "l3": ({1,2,3}) ]) ]) ])));
+
+    reset_vars();
+    check("restore: duplicate key keeps last value",
+          restore_object("#1:0\nm ([\"a\":1,\"a\":2,])\n") == 1
+          && deep_eq(m, ([ "a": 2 ])));
+
+    reset_vars();
+    check("restore: escaped characters in keys",
+          restore_object("#1:0\nm ([\"a\\\"b\":1,\"c\\\\d\":2,])\n") == 1
+          && deep_eq(m, ([ "a\"b": 1, "c\\d": 2 ])));
+
+    reset_vars();
+    check("restore: array key",
+          restore_object("#1:0\nm ([({1,2,}):3,])\n") == 1
+          && sizeof(m) == 1);
+
+    /* --- Shared values --- */
+
+    reset_vars();
+    check("restore: shared value across variables",
+          restore_object("#1:0\na <1>=({1,2,})\nb <1>\n") == 1
+          && deep_eq(a, ({1,2})) && a == b);
+
+    reset_vars();
+    check("restore: shared value within one array",
+          restore_object("#1:0\na ({<1>=({5,}),<1>,})\n") == 1
+          && a[0] == a[1] && deep_eq(a[0], ({5})));
+
+    reset_vars();
+    check("restore: self-referencing shared mapping",
+          restore_object("#1:0\nm <1>=([\"self\":<1>,])\n") == 1
+          && mappingp(m) && m["self"] == m);
+
+    /* --- Lines of unknown variables --- */
+
+    reset_vars();
+    check("restore: unknown variable is ignored",
+          restore_object("#1:0\nzzz_gone ([\"big\":({1,2,3,}),\"n\":17,])\nx 7\n") == 1
+          && x == 7 && !m);
+
+    reset_vars();
+    check("restore: shared value defined on unknown variable line",
+          restore_object("#1:0\nzzz_gone <1>=({9,8,})\na <1>\n") == 1
+          && deep_eq(a, ({9,8})));
+
+    reset_vars();
+    check("restore: unknown variable with '<' inside a string",
+          restore_object("#1:0\nzzz_gone \"a<b>c\"\nx 5\n") == 1
+          && x == 5);
+
+    reset_vars();
+    check("restore: shared numbering after unknown variable line",
+          restore_object("#1:0\nzzz_gone ([\"p\":1,])\na <1>=({4,})\nb <1>\n") == 1
+          && a == b && deep_eq(a, ({4})));
+
+    /* --- restore_value() uses the same mapping parser --- */
+
+    check("restore_value: nested mapping round trip",
+          deep_eq(restore_value(save_value(([ "a": ([ "b": ({ 1, ([ "c": 2 ]) }) ]) ]))),
+                  ([ "a": ([ "b": ({ 1, ([ "c": 2 ]) }) ]) ])));
+
+    check("restore_value: wide mapping round trip",
+          deep_eq(restore_value(save_value(([ "k": 1; 2; 3 ]))),
+                  ([ "k": 1; 2; 3 ])));
+
+    check("restore_value: empty mapping round trip",
+          deep_eq(restore_value(save_value(([]))), ([])));
+
+    /* --- Errors on malformed mappings must still be errors --- */
+
+    reset_vars();
+    check("restore: malformed mapping on known variable throws",
+          catch(restore_object("#1:0\nm ([\"a\":1\n")) != 0);
+
+    reset_vars();
+    check("restore: unterminated mapping on known variable throws",
+          catch(restore_object("#1:0\nm ([\"a\":1,")) != 0);
+
+    if (errors)
+        shutdown(1);
+    else
+        shutdown(0);
+}
+
+string *epilog(int eflag)
+{
+    run_test();
+    return 0;
+}


### PR DESCRIPTION
Two changes to the `restore_object()`/`restore_value()` path, which dominated a production profile (~37% of total CPU on a mud with big, deeply nested player save files).

**Restore mappings incrementally.** `restore_mapping()` used `restore_map_size()` to determine the size and width of a mapping before restoring it. That scan walks the complete mapping text including all nested containers, and every nested mapping then repeats the scan for its own text, so with nesting depth d the text is effectively parsed d+1 times. Now only the first entry is scanned to determine the width; the entries are then restored incrementally until the closing bracket, letting the mapping's hash part grow as usual (amortized O(1) inserts). The `max_mapping_size` check moves into the restore loop and triggers as soon as the growing mapping exceeds the limit.

**Skip lines of unknown variables without parsing.** A save file line for a variable that no longer exists in the object was fully parsed and built - including all nested containers and interned strings - only to be kept on the discarded list and freed at the end of the restore. The parse is only needed because the line might contain a `<id>=` shared value definition that a later line references. Since shared value definitions and references always contain a '<', a line without any '<' character can be skipped entirely without affecting the (strictly sequential) shared value numbering. One deliberate behaviour change: such skipped lines are no longer syntax-checked, so a malformed value on the line of a stale variable no longer aborts the restore.

The new `test/t-restore.c` covers the touched paths: empty mapping forms, widths, nesting, duplicate keys, escaped characters, shared values (including definitions on lines of unknown variables and self-referencing values), and the skip behaviour.

Measured on a save/restore benchmark modeled on the production workload (a fat nested-mapping object saved and restored in a loop, interleaved A/B runs): ~5% less CPU for the combined loop, with the gain concentrated in the restore half.