### PR TITLE
util/erq: drop the obsolete casts in the signal(SIGCLD) calls

### DIFF
--- a/src/util/erq/erq.c
+++ b/src/util/erq/erq.c
@@ -592,11 +592,11 @@ count_sigcld (int sig)
     if (!calling_signal)
     {
         calling_signal = 1;
-        (void)signal(SIGCLD, (void(*)())count_sigcld);
+        (void)signal(SIGCLD, count_sigcld);
         while (call_signal_again)
         {
             --call_signal_again;
-            (void)signal(SIGCLD, (void(*)())count_sigcld);
+            (void)signal(SIGCLD, count_sigcld);
         }
         calling_signal = 0;
     }
@@ -828,7 +828,7 @@ start_subserver (long server_num, long seed)
     childs_waited_for = 0;
 
     /* possible race conditions make switching the signal handler awkward */
-    (void)signal(SIGCLD, (void(*)())count_sigcld);
+    (void)signal(SIGCLD, count_sigcld);
 
     for (;;) /* The Loop (tm) */
     {
@@ -1542,7 +1542,7 @@ main (int argc, char **argv)
     FD_ZERO(&current_fds);
     FD_ZERO(&current_fds2);
     FD_SET(1, &current_fds);
-    (void)signal(SIGCLD, (void(*)())count_sigcld);
+    (void)signal(SIGCLD, count_sigcld);
 
     /* The main loop */
     


### PR DESCRIPTION
Current GCC defaults to C23, where an empty parameter list means (void). The historical `(void(*)())` casts around `count_sigcld` in the `signal(SIGCLD, ...)` calls therefore now produce an incompatible pointer type (`void (*)(void)` vs. `void (*)(int)`) and the erq fails to compile with -Wincompatible-pointer-types, which is an error by default on GCC 14+.

`count_sigcld()` already has the correct handler signature `void (int)`, so the casts can simply be dropped. This is the same class of fix as #106, which covered util/xerq and util/indent but not util/erq.