### PR TITLE
allow configuration of default H_FILE_ENCODING

### DIFF
--- a/src/autoconf/configure.ac
+++ b/src/autoconf/configure.ac
@@ -212,6 +212,7 @@ AC_MY_ARG_ENABLE(access-log,no,,[Log all connection attempts])
 AC_MY_ARG_ENABLE(compat-mode,no,,[Enable compat mode])
 AC_MY_ARG_ENABLE(strict-euids,no,,[Enforce euids for loading objects])
 AC_MY_ARG_ENABLE(filename-spaces,no,,[Allow space characters in filenames])
+AC_MY_ARG_WITH(default-file-encoding,ascii,,[Default for H_FILE_ENCODING])
 AC_MY_ARG_ENABLE(share-variables,no,,[Enable clone initialization from blueprint variable values])
 AC_MY_ARG_ENABLE(keyword-in,no,,[Enable 'in' as a keyword])
 AC_MY_ARG_ENABLE(use-ipv6,no,,[Enables support for IPv6])
@@ -571,6 +572,8 @@ AC_STRING_VAL_FROM_WITH(tls_crldirectory)
 AC_STRING_VAL_FROM_WITH(tls_password)
 
 AC_STRING_VAL_FROM_WITH(python_script)
+
+AC_STRING_VAL_FROM_WITH(default_file_encoding)
 
 AC_TEXT_VAL_FROM_WITH(malloc)
 
@@ -2695,6 +2698,7 @@ AC_SUBST(val_tls_crldirectory)
 AC_SUBST(val_tls_password)
 AC_SUBST(val_python_script)
 AC_SUBST(val_valgrind_redzone)
+AC_SUBST(val_default_file_encoding)
 
 dnl finally: some remaining stuff
 dnl

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -28,6 +28,11 @@
  */
 @cdef_filename_spaces@ ALLOW_FILENAME_SPACES
 
+/* The default file encoding to be used if H_FILE_ENCODING is not set. This
+ * includes compilation of the Master object (i.e. before it had a chance to
+ * actually set H_FILE_ENCODING).
+ */
+#define DEFAULT_FILE_ENCODING    @val_default_file_encoding@
 
 /* --- Runtime limits --- */
 

--- a/src/files.c
+++ b/src/files.c
@@ -1149,7 +1149,7 @@ get_file_encoding (string_t* filename, bool source, bool* ignore, bool* replace)
     {
         if (encoding == NULL)
         {
-            cd = iconv_open("utf-8", "ascii");
+            cd = iconv_open("utf-8", DEFAULT_FILE_ENCODING);
             *ignore = false;
             *replace = false;
         }
@@ -1171,7 +1171,8 @@ get_file_encoding (string_t* filename, bool source, bool* ignore, bool* replace)
         }
     }
     else
-        cd = iconv_open(encoding == NULL ? "ascii" : get_txt(encoding), "utf-8");
+        cd = iconv_open(encoding == NULL ? DEFAULT_FILE_ENCODING
+                : get_txt(encoding), "utf-8");
 
     if (!iconv_valid(cd))
         errorf("Unsupported encoding '%s'.\n", get_txt(encoding));

--- a/src/lex.c
+++ b/src/lex.c
@@ -2534,7 +2534,8 @@ set_input_source (int fd, const char* fname, string_t * str)
                 encoding = svp->u.str;
         }
 
-        yyin.cd = iconv_open("utf-8", encoding == NULL ? "ascii" : get_txt(encoding));
+        yyin.cd = iconv_open("utf-8", encoding == NULL ? DEFAULT_FILE_ENCODING
+                : get_txt(encoding));
         if (!iconv_valid(yyin.cd))
         {
             if (errno == EINVAL)

--- a/src/settings/beutelland
+++ b/src/settings/beutelland
@@ -7,6 +7,8 @@
 exec ./configure --prefix=/RoleMUD/ --libexecdir=/RoleMUD/bin --libdir=/RoleMUD/MUD-Lib --enable-erq=xerq --with-setting=beutelland $*
 exit 1
 
+# --- default file encoding ---
+with_default_file_encoding=utf8
 
 # --- Timing ---
 with_time_to_clean_up=5400


### PR DESCRIPTION
Add a configuration option --with-default-file-encoding to set the default value for H_FILE_ENCODING if this hook is not (yet) set. This allows for non-ascii Master objects.