### PR TITLE
parse: return a valid stack pointer for an empty command or pattern

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -1660,7 +1660,14 @@ v_parse_command (svalue_t *sp, int num_arg)
     /* Pattern and commands can not be empty
      */
     if (!mstrsize(cmd) || !mstrsize(pattern))
-        return MY_FALSE;
+    {
+        /* No error handler has been pushed yet, so the stack holds
+         * just the arguments.
+         */
+        sp = pop_n_elems(num_arg + 3, sp);
+        push_number(sp, 0);
+        return sp;
+    }
 
     /* Prepare some variables */
 

--- a/test/t-efuns.c
+++ b/test/t-efuns.c
@@ -1377,6 +1377,21 @@ mixed *tests = (this_object() == blueprint()) &&
             return prepos[0] == "at" && deep_eq(items, ({ 1, this_object() }));
         :)
     }),
+    ({ "parse_command with an empty command", 0,
+       (:
+            mixed *items;
+            return !parse_command("", ({ this_object() }), " 'take' %i ", items);
+        :)
+    }),
+    ({ "parse_command with an empty pattern", 0,
+       (:
+            mixed *items;
+            return !parse_command("take apple", ({ this_object() }), "", items);
+        :)
+    }),
+    ({ "parse_command with an empty command and no lvalues", 0,
+       (: !parse_command("", ({ this_object() }), " 'take' ") :)
+    }),
 #endif
 
     ({ "regmatch 1", 0, (: regmatch("abcd", "abc") == "abc" :) }),


### PR DESCRIPTION
`v_parse_command()` returns a `svalue_t*` (the new stack pointer), but the early exit for
an empty command or pattern still returned `MY_FALSE`, i.e. `NULL`:

```c
    /* Pattern and commands can not be empty
     */
    if (!mstrsize(cmd) || !mstrsize(pattern))
        return MY_FALSE;
```

`eval_instruction()` assigns the result straight to `sp` (interpret.c):

```c
    sp = (*vefun_table[instruction-EFUNV_OFFSET])(sp, numarg);
```

so `parse_command("", ob, " 'take' %i ", var)` leaves the interpreter with `sp == NULL`.
With `--check-state` the driver aborts:

```
Bad stack after evaluation.
sp: (nil) minimum expected: 0x5601af207c40
Instruction 458(parse_command), num arg -1
Current object was t-efuns
Aborted
```

Without it, the next push writes through the NULL pointer. Either way this is reachable
from LPC with a single call, so any mudlib that passes an unvalidated player command into
`parse_command()` can be crashed from the game.

## Origin

The statement predates the efun conversion: until 09e76e1b ("Make sscanf() and
parse_command() a real efun") the function was `Bool e_parse_command()`, where returning
`MY_FALSE` was correct. The conversion adapted the other return paths but not this one.
`git tag --contains 09e76e1b` lists 3.6.4 through 3.6.8, so every release since 3.6.4 is
affected.

Note that this is a different problem from the one fixed in 3a44b176 ("Fixed several
problems with parse_command()"), which did not touch this return.

## Fix

Pop the arguments and push 0, matching the regular failure path at the end of the function.
At this point no error handler has been pushed yet, so the stack holds exactly the
`num_arg + 3` arguments (`num_arg` has already been decremented by 3 for the command,
object and pattern arguments).

## Alternatives considered

- **Raise an error instead.** An empty pattern is arguably a caller bug, so `errorf()` would
  be defensible. I went with returning 0 because the documented contract is "result is 1 if
  the command could be fully matched, and 0 otherwise", and a pattern that cannot match
  anything is exactly the "otherwise" case. It also keeps existing mudlib code working:
  anyone who currently passes an empty command gets the false they already expect, rather
  than a new runtime error. Happy to switch if you prefer the stricter behaviour.
- **Move the check before the argument fixups.** The check needs the trimmed strings, and
  the trimmed values have already been written back into the stack arguments at that point,
  so popping is required in any case. Keeping the check where it is makes the change minimal.

## Testing

Three cases added to `test/t-efuns.c` next to the existing `parse_command` tests: an empty
command, an empty pattern, and an empty command without lvalue arguments. Each of them
aborts the driver without the fix (verified by reverting `src/parse.c` and rebuilding).

Full suite with the fix (`test/run.sh`, which runs with `--check-refcounts --check-state 2`):
24721 checks passed, no failures, "Success: No lost block".

I also ran a separate stack-balance check (not included in the patch) that calls the empty
path with 0, 1 and 3 lvalue arguments, inside a larger expression with live values on either
side, nested in another call, and 2000 times in a loop, verifying that surrounding values and
the passed lvalues are untouched. An off-by-one in the pop count would show up there. All
checks pass, and the same run under `-fsanitize=address,undefined` reports nothing in
`parse.c`.