### PR TITLE
pkg-json: bound the recursion in json_serialize()

### DIFF
--- a/src/pkg-json.c
+++ b/src/pkg-json.c
@@ -33,6 +33,7 @@
 #include "structs.h"
 #include "mstrings.h"
 #include "interpret.h"
+#include "ptrtable.h"
 #include "simulate.h"
 #include "xalloc.h"
 
@@ -42,17 +43,47 @@
 #include <assert.h>
 #include <stdio.h>
 
+/* Maximum nesting depth accepted by json_serialize().
+ *
+ * The serializer recurses once per container level, and so do json-c's
+ * printer and its object destructor afterwards. Without a limit a
+ * sufficiently nested (but perfectly acyclic) value overflows the C stack:
+ * with the default 8 MB stack the recursion dies at a nesting depth of
+ * roughly 40000. The limit below keeps a wide margin to that, while still
+ * being far deeper than anything json-c can read back - its tokener
+ * defaults to a maximum nesting depth of 32.
+ */
+#define MAX_JSON_NESTING_DEPTH 1000
+
+/* Context for one json_serialize() call.
+ *
+ * <ptable> holds the containers on the current path from the root to the
+ * value being serialized, so that a container containing itself can be
+ * detected. <depth> is the length of that path.
+ */
+struct json_serialize_ctx {
+    struct pointer_table *ptable;
+    int                   depth;
+};
+
+/* Payload for walk_mapping(): the JSON object to fill and the context. */
+struct json_walk_ctx {
+    struct json_object        *parent;
+    struct json_serialize_ctx *ctx;
+};
+
 struct json_error_handler_s {
-    error_handler_t     head;
-    struct json_object *jobj;
+    error_handler_t       head;
+    struct json_object   *jobj;
+    struct pointer_table *ptable;
 };
 
 static void json_error_cleanup(error_handler_t *arg) __attribute__((nonnull(1)));
-static INLINE bool push_json_error_handler(struct json_object *jobj) __attribute__((nonnull(1)));
-static void ldmud_json_walker(svalue_t *key, svalue_t *val, void *parent) __attribute__((nonnull(1,2,3)));
+static INLINE bool push_json_error_handler(struct json_object *jobj, struct pointer_table *ptable) __attribute__((nonnull(1)));
+static void ldmud_json_walker(svalue_t *key, svalue_t *val, void *extra) __attribute__((nonnull(1,2,3)));
 static INLINE void ldmud_json_attach(struct json_object *parent, const char *key, struct json_object *val) __attribute__((nonnull(1,3)));
 svalue_t *ldmud_json_parse (svalue_t *sp, struct json_object *val) __attribute__((nonnull(1,2)));
-struct json_object *ldmud_json_serialize (svalue_t *sp, struct json_object *parent, const char *key) __attribute__((nonnull(1)));
+struct json_object *ldmud_json_serialize (svalue_t *sp, struct json_object *parent, const char *key, struct json_serialize_ctx *ctx) __attribute__((nonnull(1,4)));
 
 /*-------------------------------------------------------------------------*/
 /*                           EFUNS                                         */
@@ -98,7 +129,7 @@ f_json_parse (svalue_t *sp)
         errorf("json_parse(): could not parse string - probably illegal JSON format.\n");
     }
     // Push errorhandler with json object in case ldmud_json_parse calls errorf().
-    if (!push_json_error_handler(parsed))
+    if (!push_json_error_handler(parsed, NULL))
     {
         json_object_put(parsed);
         errorf("json_parse(): could not allocate memory for error handler.\n");
@@ -154,7 +185,8 @@ f_json_serialize (svalue_t *sp)
 {
     struct json_object *parent = NULL;
     struct json_object *jobj = NULL;
-    
+    struct json_serialize_ctx ctx = { NULL, 0 };
+
     // In case of simple types, this is straight-forward. But for 'container'
     // types like arrays, mappings, structs, it gets more complicated.
     switch(sp->type)
@@ -163,7 +195,7 @@ f_json_serialize (svalue_t *sp)
         case T_FLOAT:
         case T_STRING:
             // just create a json object containing the value.
-            jobj = ldmud_json_serialize(sp, NULL, NULL);
+            jobj = ldmud_json_serialize(sp, NULL, NULL, &ctx);
             parent = jobj;
             break;
         default:
@@ -181,18 +213,33 @@ f_json_serialize (svalue_t *sp)
         errorf("json_serialize(): could not create root JSON object (may be out of memory?).\n");
         return sp;  // not reached
     }
+    if (parent != jobj) // for container types
+    {
+        // The container may contain itself, directly or indirectly. The
+        // pointer table records the containers on the path from the root to
+        // the value currently being serialized, so that such a cycle is
+        // detected instead of recursing until the C stack is exhausted.
+        ctx.ptable = new_pointer_table();
+        if (!ctx.ptable)
+        {
+            json_object_put(parent);
+            errorf("json_serialize(): could not allocate memory for the pointer table.\n");
+        }
+    }
     // Push errorhandler with the json object in case there is a later call
     // to errorf().
-    if (!push_json_error_handler(parent))
+    if (!push_json_error_handler(parent, ctx.ptable))
     {
         json_object_put(parent);
+        if (ctx.ptable)
+            free_pointer_table(ctx.ptable);
         errorf("json_serialize(): could not allocate memory for error handler.\n");
     }
     if (parent != jobj) // for container types
     {
         // create the json object with the 'real' data. It will be attached to
         // parent for freeing in case of errors.
-        jobj = ldmud_json_serialize(sp, parent, NULL);
+        jobj = ldmud_json_serialize(sp, parent, NULL, &ctx);
     }
     // inter_sp now points to one value above our argument (sp).
     // We free the argument and let put_c_string() put the new string at that
@@ -217,9 +264,10 @@ f_json_serialize (svalue_t *sp)
 
 /*-------------------------------------------------------------------------*/
 static INLINE bool
-push_json_error_handler(struct json_object * jobj)
+push_json_error_handler(struct json_object * jobj, struct pointer_table *ptable)
 /* An error handler is pushed onto the value stack so that the given json_object
- * is safely freed either by manually freeing the svalue on the stack or during
+ * and the given pointer table (which may be NULL) are safely freed either by
+ * manually freeing the svalue on the stack or during
  * stack unwinding during errorf().
  * inter_sp has to point to the top-of-stack before calling and is updated to
  * point to the error handler svalue!
@@ -233,6 +281,7 @@ push_json_error_handler(struct json_object * jobj)
         return false;
     }
     handler->jobj = jobj;
+    handler->ptable = ptable;
     /* now push error handler onto the value stack */
     push_error_handler(json_error_cleanup, &(handler->head));
     return true;
@@ -241,7 +290,8 @@ push_json_error_handler(struct json_object * jobj)
 /*-------------------------------------------------------------------------*/
 static void
 json_error_cleanup (error_handler_t *arg)
-/* Frees the json object contained in the error handler and the handler.
+/* Frees the json object contained in the error handler, the pointer table
+ * and the handler.
  * Called from free_svalue() (e.g. during stack unwinding in case of errors).
  */
 {
@@ -249,8 +299,62 @@ json_error_cleanup (error_handler_t *arg)
     // free the referenced jobj (decrease refcounter)
     if (info->jobj)
         json_object_put(info->jobj);
+    if (info->ptable)
+        free_pointer_table(info->ptable);
     xfree(info);
 }
+
+/*-------------------------------------------------------------------------*/
+static void
+json_enter_container (struct json_serialize_ctx *ctx, void *container)
+/* Note that <container> is entered, i.e. put onto the path of containers
+ * currently being serialized.
+ *
+ * Raises an error if <container> is already on that path (which means the
+ * value contains itself and the recursion would not terminate), or if the
+ * path has become too long.
+ *
+ * <container> may be NULL for container-like values without an identity of
+ * their own (e.g. a range of an array); those only count towards the depth.
+ */
+{
+    if (container != NULL)
+    {
+        struct pointer_record *prec;
+
+        prec = find_add_pointer(ctx->ptable, container, MY_TRUE);
+        if (prec == NULL)
+            errorf("json_serialize(): out of memory.\n");
+        if (prec->id_number)
+            errorf("json_serialize(): cyclic structure.\n");
+        prec->id_number = 1;
+    }
+
+    if (++ctx->depth > MAX_JSON_NESTING_DEPTH)
+        errorf("json_serialize(): nesting too deep, limit is %d.\n"
+              , MAX_JSON_NESTING_DEPTH);
+} /* json_enter_container() */
+
+/*-------------------------------------------------------------------------*/
+static void
+json_leave_container (struct json_serialize_ctx *ctx, void *container)
+/* Note that <container> has been serialized completely and is no longer on
+ * the path, so that it may legitimately appear again as a sibling.
+ *
+ * Not called when the serialization was aborted by an error - in that case
+ * the whole table is freed by the error handler anyway.
+ */
+{
+    if (container != NULL)
+    {
+        struct pointer_record *prec;
+
+        prec = lookup_pointer(ctx->ptable, container);
+        if (prec != NULL)
+            prec->id_number = 0;
+    }
+    ctx->depth--;
+} /* json_leave_container() */
 
 /*-------------------------------------------------------------------------*/
 svalue_t *
@@ -356,9 +460,12 @@ ldmud_json_parse (svalue_t *sp, struct json_object *jobj)
 
 /*-------------------------------------------------------------------------*/
 static void
-ldmud_json_walker(svalue_t *key, svalue_t *val, void *parent)
+ldmud_json_walker(svalue_t *key, svalue_t *val, void *extra)
 /*
-   * Adds svalue <val> to json object <parent> under the key <key>.
+   * Adds svalue <val> to the json object in <extra> under the key <key>.
+   *
+   * <extra> points to a struct json_walk_ctx holding the JSON object to fill
+   * and the serialization context.
    * 
    * Note: <key> must be of type T_STRING.
    *       The mapping MUST have at least one value per key.
@@ -368,7 +475,7 @@ ldmud_json_walker(svalue_t *key, svalue_t *val, void *parent)
    * WARNING: might call errorf().
 */
 {
-    struct json_object *jobj = (struct json_object *)parent;
+    struct json_walk_ctx *walk = (struct json_walk_ctx *)extra;
     if (key->type != T_STRING)
     {
         errorf("json_serialize(): JSON supports only string keys, but got: %s\n",
@@ -376,7 +483,7 @@ ldmud_json_walker(svalue_t *key, svalue_t *val, void *parent)
         /* NOTREACHED */
         return;
     }
-    ldmud_json_serialize(val, jobj, get_txt(key->u.str));
+    ldmud_json_serialize(val, walk->parent, get_txt(key->u.str), walk->ctx);
 } // ldmud_json_walker
 
 /*-------------------------------------------------------------------------*/
@@ -403,10 +510,14 @@ ldmud_json_attach(struct json_object *parent, const char *key, struct json_objec
 
 /*-------------------------------------------------------------------------*/
 struct json_object *
-ldmud_json_serialize (svalue_t *sp, struct json_object *parent, const char *key)
+ldmud_json_serialize (svalue_t *sp, struct json_object *parent, const char *key, struct json_serialize_ctx *ctx)
 /*
    * Creates a JSON object containing the data of the svalue <sp> points to.
    * To do this, it calls itself recursively if needed (for container types).
+   *
+   * <ctx> carries the containers on the current path (for cycle detection)
+   * and the current nesting depth. Serializing a value that contains itself
+   * or is nested too deeply raises an error.
    * Only T_NUMBER, T_FLOAT, T_STRINGS, T_POINTER, T_MAPPING and T_STRUCT are 
    * serialized. All other LPC types cause a runtime error.
    *
@@ -460,42 +571,60 @@ ldmud_json_serialize (svalue_t *sp, struct json_object *parent, const char *key)
         break;
     
     case T_POINTER:
+        json_enter_container(ctx, val->u.vec);
+
         jobj = json_object_new_array();
         // the created object has to be attached to the parent immediately to
         // prevent any memory leaks in case there is a call to errorf() later.
         ldmud_json_attach(parent, key, jobj);
 
         for (int i = 0; i < VEC_SIZE(val->u.vec); ++i)
-            ldmud_json_serialize(&val->u.vec->item[i], jobj, NULL);
-        
+            ldmud_json_serialize(&val->u.vec->item[i], jobj, NULL, ctx);
+
+        json_leave_container(ctx, val->u.vec);
         break;
-    
+
     case T_MAPPING:
+    {
+        struct json_walk_ctx walk;
+
         if (val->u.map->num_values != 1)
           errorf("json_serialize(): can only serialize mappings with width 1, "
                  "but got mapping with width %"PRIdPINT".\n",
                  val->u.map->num_values);
-        
+
+        json_enter_container(ctx, val->u.map);
+
         jobj = json_object_new_object();
         // the created object has to be attached to the parent immediately to
         // prevent any memory leaks in case there is a call to errorf() later.
         ldmud_json_attach(parent, key, jobj);
 
-        walk_mapping(val->u.map, &ldmud_json_walker, jobj);
+        walk.parent = jobj;
+        walk.ctx = ctx;
+        walk_mapping(val->u.map, &ldmud_json_walker, &walk);
+
+        json_leave_container(ctx, val->u.map);
         break;
+    }
     case T_STRUCT:
     {
         struct_t  * st = val->u.strct;
+
+        json_enter_container(ctx, st);
+
         jobj = json_object_new_object();
         // the created object has to be attached to the parent immediately to
         // prevent any memory leaks in case there is a call to errorf() later.
         ldmud_json_attach(parent, key, jobj);
-        
+
         // Now loop over all members and assign the data
         for (int i  = 0; i < struct_size(st); ++i)
         {
-            ldmud_json_serialize(&(st->member[i]),jobj,get_txt(st->type->member[i].name));
+            ldmud_json_serialize(&(st->member[i]),jobj,get_txt(st->type->member[i].name), ctx);
         }
+
+        json_leave_container(ctx, st);
         break;
     }
 
@@ -521,6 +650,10 @@ ldmud_json_serialize (svalue_t *sp, struct json_object *parent, const char *key)
             if (!get_iterator(sp, &it, true))
                 fatal("Illegal lvalue type %d\n", sp->x.lvalue_type);
 
+            // A range has no identity of its own to register, but it still
+            // adds a level to the nesting depth.
+            json_enter_container(ctx, NULL);
+
             jobj = json_object_new_array();
             if (parent) ldmud_json_attach(parent, key, jobj);
 
@@ -529,8 +662,10 @@ ldmud_json_serialize (svalue_t *sp, struct json_object *parent, const char *key)
                 svalue_t *item = it.next_value(&it);
                 if (!item)
                     break;
-                ldmud_json_serialize(item, jobj, NULL);
+                ldmud_json_serialize(item, jobj, NULL, ctx);
             }
+
+            json_leave_container(ctx, NULL);
         }
         break;
     }

--- a/test/t-efuns.c
+++ b/test/t-efuns.c
@@ -1944,8 +1944,66 @@ mixed *tests = (this_object() == blueprint()) &&
     ({ "json_parse 3", 0,
         (: deep_eq(json_parse(json_teststring), json_testdata) :) }),
     ({ "json_serialize + json_parse 1", 0,
-        (: deep_eq(json_parse(json_serialize(json_testdata)), json_testdata) 
+        (: deep_eq(json_parse(json_serialize(json_testdata)), json_testdata)
          :) }),
+    /* The cycles below are broken again before returning: a value that
+     * contains itself keeps itself alive, and the garbage collection check
+     * at the end of the test run would report it as a lost block.
+     */
+    ({ "json_serialize of a self-containing array", 0,
+        (:
+            mixed *a = ({ 0 });
+            int errors;
+            a[0] = a;
+            errors = catch(json_serialize(a); nolog) != 0;
+            a[0] = 0;
+            return errors;
+        :) }),
+    ({ "json_serialize of a self-containing mapping", 0,
+        (:
+            mapping m = ([ "self": 0 ]);
+            int errors;
+            m["self"] = m;
+            errors = catch(json_serialize(m); nolog) != 0;
+            m["self"] = 0;
+            return errors;
+        :) }),
+    ({ "json_serialize of an indirect cycle", 0,
+        (:
+            mixed *a = ({ 0 });
+            mapping m = ([ "a": a ]);
+            int errors;
+            a[0] = m;
+            errors = catch(json_serialize(a); nolog) != 0;
+            a[0] = 0;
+            return errors;
+        :) }),
+    ({ "json_serialize of a too deeply nested array", TF_ERROR,
+        (:
+            mixed a = ({ 1 });
+            for (int i = 0; i < 2000; i++)
+                a = ({ a });
+            return json_serialize(a);
+        :) }),
+    ({ "json_serialize of a repeated (acyclic) array", 0,
+        (:
+            mixed *inner = ({ 1, 2 });
+            return json_serialize(({ inner, inner, inner }))
+                   == "[ [ 1, 2 ], [ 1, 2 ], [ 1, 2 ] ]";
+        :) }),
+    ({ "json_serialize of a repeated (acyclic) mapping", 0,
+        (:
+            mapping m = ([ "x": 1 ]);
+            return json_serialize(({ m, m })) == "[ { \"x\": 1 }, { \"x\": 1 } ]";
+        :) }),
+    ({ "json_serialize is usable after a cycle error", 0,
+        (:
+            mixed *a = ({ 0 });
+            a[0] = a;
+            catch(json_serialize(a); nolog);
+            a[0] = 0;
+            return deep_eq(json_parse(json_serialize(json_testdata)), json_testdata);
+        :) }),
 #endif // __JSON__
 
 #ifdef __MYSQL__


### PR DESCRIPTION
`ldmud_json_serialize()` recurses into arrays, mappings and structs without any
bound. Two LPC values crash the driver:

```lpc
mixed *a = ({ 0 });
a[0] = a;
json_serialize(a);              // segfault: infinite recursion

mixed a = ({ 1 });
for (int i = 0; i < 50000; i++)
    a = ({ a });
json_serialize(a);              // segfault: C stack exhausted
```

Self-referencing values are perfectly legal in LPC, so the first case is a one-line
crash available to anyone who can call the efun. It is easy to hit by accident: a
mudlib that serializes its own data structures only needs one back reference
(a container that also references its parent) somewhere in the graph.

The other serializers in the tree already solve this: `save_svalue()` (object.c) and
`svalue_to_string()` (sprintf.c) both track the containers they have entered in a
`pointer_table`. `pkg-json.c` has no such handling - `grep -c pointer_table pkg-json.c`
returns 0.

For the depth case I instrumented the recursion to find out where it dies: with the
default 8 MB stack our own recursion reaches a nesting depth of roughly 40000 before
the segfault, i.e. it dies before json-c's printer or its destructor - which recurse
over the same tree afterwards - even run.

`json_parse()` is not affected: json-c's tokener enforces its own maximum nesting
depth (32 by default) and the existing code turns that into a clean error.

## Fix

Carry a small context through the recursion holding a `pointer_table` and the current
depth.

**Cycle detection is path-based, not visit-based.** A container is registered when it
is entered and unregistered when it has been serialized completely, so only a
container that is its own ancestor is reported as a cycle. This matters: repeating
the *same* container several times side by side is legal and works today, and must
keep working -

```lpc
mixed *inner = ({ 1, 2 });
json_serialize(({ inner, inner, inner }));   // "[ [ 1, 2 ], [ 1, 2 ], [ 1, 2 ] ]"
```

A table that merely recorded "seen" pointers would reject this. There are test cases
for it.

**Depth limit.** `MAX_JSON_NESTING_DEPTH` (1000) bounds the nesting for values that
are deep but acyclic. The value keeps a wide margin to the observed ~40000 and is
still far deeper than anything json-c will read back with its default tokener depth
of 32.

The pointer table is owned by the error handler that the efun already pushes for the
JSON object, so it is released on the normal path and during stack unwinding alike.

## Alternatives considered

- **Emit a back reference instead of an error.** `svalue_to_string()` prints `({#1 ... })`
  for a repeated container, which is what makes `sprintf("%O", ...)` work on cyclic
  data. JSON has no such notation, so there is nothing to emit - an error is the only
  faithful answer. Silently substituting `null` for the cycle was the other option; I
  did not take it because it turns a broken value into valid-looking output.
- **`assert_stack_gap()` instead of a depth counter.** That is what `save_svalue()`
  uses, but it only guards the gap between heap and C stack. On a 64-bit host with a
  downward-growing stack far above the heap it never fires - see the discussion in
  \#129 - so it would not have caught the deep-nesting crash.
- **Eval cost per node**, which the `TODO` at the top of the file asks for. It is the
  right thing for fairness and I would be glad to add it, but it cannot replace the
  depth limit: with a large `max_eval_cost` the recursion would still be allowed to go
  far deeper than the C stack permits.
- **Making the limit configurable** (`configure_driver()` or a configure-time option)
  rather than a compile-time constant. Happy to do that if you would prefer it; I kept
  it simple for now.

## Testing

Seven cases added to `test/t-efuns.c` in the existing `__JSON__` block: a
self-containing array, a self-containing mapping, an indirect cycle through a mapping,
a too deeply nested array, the two "repeated but acyclic" cases above, and one that
checks the efun still works after a cycle error. Each of the crash cases segfaults the
driver without the patch.

The cycle tests break the cycle again before returning. A value that contains itself
keeps itself alive - LPC is reference counted with no cycle collector - and the
garbage collection check at the end of the test run would otherwise report it as a
lost block. That is independent of this change: building such a value and dropping it
without calling `json_serialize()` at all produces the same lost block.

Full suite with json-c enabled: 23034 checks pass, no failures, "Success: No lost
block". The same run under `-fsanitize=address,undefined` reports nothing in
`pkg-json.c`.