### PR TITLE
sprintf: escape %Q strings without an unbounded alloca()

### DIFF
--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -650,11 +650,13 @@ string_to_string (fmt_state_t *st, string_t* obj, size_t index1, size_t index2, 
         }
         else
         {
-            char *tmpstr, *src, *dest;
-            size_t tmpsize = 10 * (index2-index1);
-
-            /* Allocate the temporary string */
-            tmpstr = alloca(tmpsize);
+            /* Escape into a small buffer of fixed size, flushing it into
+             * <str> whenever it might not have room for another character.
+             * (The buffer must be at least 10 bytes for
+             * get_escaped_character().)
+             */
+            char tmpstr[512];
+            char *src, *dest;
 
             src = get_txt(obj) + index1;
             dest = tmpstr;
@@ -673,10 +675,17 @@ string_to_string (fmt_state_t *st, string_t* obj, size_t index1, size_t index2, 
                     i += clen;
                 }
 
-                dest += get_escaped_character(c, dest, tmpstr + tmpsize - dest);
+                if ((size_t)(tmpstr + sizeof(tmpstr) - dest) < 10)
+                {
+                    straddn(st, &str, tmpstr, dest - tmpstr);
+                    dest = tmpstr;
+                }
+
+                dest += get_escaped_character(c, dest, tmpstr + sizeof(tmpstr) - dest);
             } /* for() */
 
-            straddn(st, &str, tmpstr, dest - tmpstr);
+            if (dest != tmpstr)
+                straddn(st, &str, tmpstr, dest - tmpstr);
         }
     }
 

--- a/test/t-efuns.c
+++ b/test/t-efuns.c
@@ -1456,6 +1456,42 @@ mixed *tests = (this_object() == blueprint()) &&
     ({ "sprintf 11", 0, (: sprintf("%=-4s\n", "A B\rC D E\n") == "A B\nC D\nE\n" :) }),
     ({ "sprintf 12", 0, (: sprintf("%=-4s\n", "A B\rC D\rE F G\n") == "A B\nC D\nE F\nG\n" :) }),
 
+    /* %Q escaping: the escaped output is assembled in a fixed size buffer,
+     * so make sure that characters straddling a buffer boundary and the
+     * longest escape sequences still come out correctly.
+     */
+    ({ "sprintf %Q control characters", 0,
+        (: sprintf("%Q", "a\nb\tc\rd\ae\bf") == "\"a\\nb\\tc\\rd\\ae\\bf\"" :) }),
+    ({ "sprintf %Q hex escape", 0,
+        (: sprintf("%Q", "\x01\x1f") == "\"\\x01\\x1f\"" :) }),
+    ({ "sprintf %Q unicode escape", 0,
+        (: sprintf("%Q", "\u00e4\u20ac") == "\"\\u00e4\\u20ac\"" :) }),
+    ({ "sprintf %Q wide unicode escape", 0,
+        (: sprintf("%Q", "\U0001f600") == "\"\\U0001f600\"" :) }),
+    ({ "sprintf %Q across the buffer boundary", 0,
+        (:
+            for (int i = 1; i <= 120; i++)
+                if (sprintf("%Q", "\u00e4" * i) != "\"" + ("\\u00e4" * i) + "\"")
+                    return 0;
+            return 1;
+        :) }),
+    ({ "sprintf %Q with the longest escape at the boundary", 0,
+        (:
+            for (int i = 0; i < 60; i++)
+                if (sprintf("%Q", ("a" * i) + "\U0001f600")
+                    != "\"" + ("a" * i) + "\\U0001f600\"")
+                    return 0;
+            return 1;
+        :) }),
+    ({ "sprintf %Q of a long string", 0,
+        (: sprintf("%Q", "\u00e4" * 10000) == "\"" + ("\\u00e4" * 10000) + "\"" :) }),
+    /* The result exceeds the sprintf buffer, so this must fail with a regular
+     * error - it used to put ten times the string length on the C stack and
+     * crash the driver before ever getting there.
+     */
+    ({ "sprintf %Q of a very long string", TF_ERROR,
+        (: sprintf("%Q", "\u00e4" * 500000) :) }),
+
     ({ "sprintf doc01", 0, (: sprintf("foo")                     == "foo"           :) }),
     ({ "sprintf doc02", 0, (: sprintf("%s","foo")                == "foo"           :) }),
     ({ "sprintf doc03", 0, (: sprintf("%7s","foo")               == "    foo"       :) }),


### PR DESCRIPTION
`string_to_string()` escapes a string into a temporary buffer that it allocates on
the C stack with ten times the string length:

```c
    size_t tmpsize = 10 * (index2-index1);

    /* Allocate the temporary string */
    tmpstr = alloca(tmpsize);
```

Nothing bounds that. With the default 8 MB stack a string of about 900 KB is enough
to overflow it and kill the driver:

```lpc
sprintf("%Q", "ä" * 450000);       // segfault
```

The escaping path is entered as soon as the string contains a single character below
0x20 or above 0x7E, so on a mud that is not pure ASCII it is the normal path rather
than a corner case - one umlaut anywhere in the string is enough.

There is no limit that keeps this out of reach in a default build: `max_array_size`
does not apply to strings, and the `BUFF_SIZE` check that catches oversized *results*
only runs after the `alloca()` has already happened. That is visible in the failure
pattern - a 100 KB string still produces the regular `(s)printf(): BUFF_SIZE
overflowed` error, a 2 MB string segfaults before reaching it.

## Fix

Escape into a fixed 512 byte buffer and flush it into the output whenever it might
not have room for another character (`get_escaped_character()` writes at most 10
bytes, for `\U########`). Stack usage is now constant and independent of the string
length, and no dynamic allocation - and therefore no error handler - is needed.

Oversized strings now fail with the regular `BUFF_SIZE overflowed` error instead of
crashing, which is what the smaller sizes already did.

The output is unchanged. I verified that by running an escaping test suite against
both the patched and the unpatched driver and diffing the results - they are
byte-identical.

## Related, but deliberately not in this PR

`array.c` uses the same technique in `sort_array()` (two `alloca()`s of
`size * sizeof(svalue_t)`), `get_array_order()`, `filter()`, `filter_objects()` and
`allocate()`. `sort_array()` on a 400000 element array segfaults the same way.

Those are only reachable once `max_array_size` is raised or disabled, though - the
default of 5000 keeps them at a harmless 160 KB - and the fix there is a different
one (the sort needs the whole array at once, so it would have to move to `xalloc()`
with an error handler rather than being chunked). I would rather send that as its
own patch than mix it in here. Say the word and I will.

One thing worth noting for whoever picks that up: the

```c
    if (!source || !dest)
        errorf("Stack overflow in sort_array()");
```

checks in those functions cannot fire. `my-alloca.h` maps `alloca()` to
`__builtin_alloca()` on GCC, which never returns NULL - it just moves the stack
pointer.

## Also noticed while testing (not addressed here)

`sprintf("%Q", "a\"b")` returns `"a"b"` rather than `"a\"b"`. The `needquote` scan
that decides whether escaping is needed only looks for characters below 0x20 or
above 0x7E, while `get_escaped_character()` also escapes `"` and `\`. A string
containing only those two characters therefore takes the raw path and comes out
unescaped. This is pre-existing (it behaves identically on master) and it is a change
in output rather than a crash fix, so I left it out of this patch. Happy to send a
separate one.

## Testing

Eight cases added to `test/t-efuns.c` next to the existing sprintf tests: the escape
sequences of each length (`\n`, `\x01`, `ä`, `\U0001f600`), two loops that walk
a character across the 512 byte buffer boundary - including the 10 byte escape, which
is the case that would break a naive flush condition - a long string, and a very long
one that must raise a regular error. The last one segfaults the driver without the
patch.

Full suite: 23618 checks pass, no failures, "Success: No lost block". The same run
under `-fsanitize=address,undefined` reports nothing in `sprintf.c`.