### PR TITLE
simulate: keep limit_error_format() inside its buffer

### DIFF
--- a/src/simulate.c
+++ b/src/simulate.c
@@ -726,28 +726,37 @@ limit_error_format (char *fixed_fmt, size_t fixed_fmt_len, const char *fmt)
     ffptr = fixed_fmt;
     while (*fmt && ffptr < fixed_fmt + fixed_fmt_len-1)
     {
-      if ((*ffptr++=*fmt++)=='%')
+      if (*fmt == '%' && fmt[1] == 's')
       {
-        if (*fmt == 's')
-        {
-          *ffptr++ = '.';
-          *ffptr++ = '2';
-          *ffptr++ = '0';
-          *ffptr++ = '0';
-        }
+        /* Turn the '%' into "%.200"; the 's' is copied by the next
+         * iteration. Only do so if the five bytes still fit, otherwise
+         * stop here and let the truncation below handle it - the loop
+         * condition alone only guarantees room for a single byte.
+         */
+        if (ffptr + 5 > fixed_fmt + fixed_fmt_len-1)
+            break;
+
+        *ffptr++ = *fmt++;
+        *ffptr++ = '.';
+        *ffptr++ = '2';
+        *ffptr++ = '0';
+        *ffptr++ = '0';
       }
+      else
+        *ffptr++ = *fmt++;
     }
 
     if (*fmt)
     {
         /* We reached the end of the fixed_fmt buffer before
          * the <fmt> string was complete: mark this error message
-         * as truncated.
-         * ffptr points to the last byte in the <fixed_fmt> buffer.
+         * as truncated by overwriting the last three bytes written
+         * (fewer if less than three have been written at all).
          */
-        ffptr[-3] = '.';
-        ffptr[-2] = '.';
-        ffptr[-1] = '.';
+        char *mark = (ffptr - fixed_fmt >= 3) ? ffptr - 3 : fixed_fmt;
+
+        while (mark < ffptr)
+            *mark++ = '.';
     }
 
     *ffptr = '\0';


### PR DESCRIPTION
`limit_error_format()` rewrites every `%s` in an error format string to `%.200s`
"to avoid buffer overflows" - and overflows its own output buffer while doing so.

The loop condition only guarantees room for a single byte:

```c
    while (*fmt && ffptr < fixed_fmt + fixed_fmt_len-1)
    {
      if ((*ffptr++=*fmt++)=='%')
      {
        if (*fmt == 's')
        {
          *ffptr++ = '.';
          *ffptr++ = '2';
          *ffptr++ = '0';
          *ffptr++ = '0';
        }
      }
    }
```

but the `%s` case writes five. If a `%s` falls on the last position the loop allows
(index `len-2`), the four expansion bytes run to index `len+2`, the truncation marker
that follows writes `'.'` over three of those, and the final `*ffptr = '\0'` lands at
index `len+3`. That is four bytes past the end of a caller-provided buffer - on the
stack for every caller.

Reproduced with the function copied verbatim into a harness:

```
==1917024==ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 1 at 0x602000000020 thread T0
    #0 limit_error_format lef-test.c:20
0x602000000020 is located 0 bytes to the right of 16-byte region
```

and, with a canary instead of ASan, exactly four bytes: `[2e][2e][2e][00]` - the three
dots and the terminator.

The callers pass `char fixed_fmt[ERROR_FMT_LEN]` (2048; simulate.c `errorf()`,
`warnf()`, pkg-python.c) and `char fixed_fmt[1000]` (lex.c `yyerrorf()`, lang.c
`yyerrorf()`/`yywarnf()`).

## How reachable is this?

Not, with the format strings currently in the tree - I checked, and I would rather say
so than oversell it. Every format reaching this function is a driver literal, and none
of them come close to 1000 bytes. In particular the mudlib cannot supply one:
`raise_error()` goes through `ERRORF(("%s", get_txt(sp->u.str)))`, so the *argument* is
mudlib data but the format is not.

What makes it worth fixing anyway is that this is the function the driver relies on to
make error formats safe, it is called from the error path where things are already
going wrong, and the failure mode is a stack write past a buffer - which
`_FORTIFY_SOURCE`/stack protector turn into an abort. It is one added bounds check.

## Fix

Handle `%s` as one unit and only expand it when the five bytes actually fit; otherwise
stop and let the existing truncation path mark the message. Output is unchanged for
everything that fitted before.

The truncation marker needed a guard as well. It writes `ffptr[-3]`, `ffptr[-2]`,
`ffptr[-1]` assuming at least three bytes have been written - with the new early exit
a format starting with `%s` in a very small buffer can leave `ffptr` at the start of
the buffer, and the marker would then write *before* it. (The same underflow exists
today for `fixed_fmt_len == 1`.) It now only overwrites what has actually been written.

## Testing

The bug is not reachable from LPC, so there is no meaningful test case for the
driver's test suite and I have not added one.

Instead I verified the rewrite against the original by running both over 2219963
combinations of buffer size (4..40) and format string (built from `a`, `%s`, `%d`,
`%%`, `%`, `s`, `xy`, `%s%s` in every arrangement), with a canary behind each buffer:

```
Faelle geprueft       : 2219963
alte Fassung ueberlief: 522341
neue Fassung ueberlief: 0
Ausgabe abweichend    : 0   (nur wo die alte korrekt blieb)
```

So the old code overflows in about a quarter of those cases, the new one in none, and
wherever the old code stayed inside its buffer both produce byte-identical output.

In the driver itself: a run of assorted runtime errors (`raise_error`, unknown
function, division by zero, wrong argument type, a 300 character message, index out of
bounds) produces byte-identical messages before and after. Full suite: 25438 checks
pass, no failures, "Success: No lost block", and the same run under
`-fsanitize=address,undefined` reports nothing in `simulate.c`.