### PR TITLE
interpret: make <<= and >>= agree with << and >>

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -15923,9 +15923,6 @@ again:
         TYPE_TEST_LEFT(sp, T_LVALUE);
 #endif
 
-        if (shift > MAX_SHIFT)
-            shift = MAX_SHIFT;
-
         /* Set argp to the actual value designated by sp[0].
          * We handle special lvalues right away.
          */
@@ -16028,9 +16025,6 @@ again:
         TYPE_TEST_LEFT(sp, T_LVALUE);
 #endif
 
-        if (shift > MAX_SHIFT)
-            shift = MAX_SHIFT + 1;
-
         /* Set argp to the actual value designated by sp[0].
          * We handle special lvalues right away.
          */
@@ -16094,10 +16088,16 @@ again:
         case T_NUMBER:
             if (sp[-1].type == T_NUMBER)
             {
-                if (shift > MAX_SHIFT)
+                /* Same result as F_RSH: shifting out all bits leaves the
+                 * sign, i.e. 0 for a non-negative and -1 for a negative
+                 * number.
+                 */
+                if (shift <= MAX_SHIFT)
+                    argp->u.number >>= shift;
+                else if (argp->u.number >= 0)
                     argp->u.number = 0;
                 else
-                    argp->u.number >>= shift;
+                    argp->u.number = -1;
             }
             else
             {

--- a/test/t-language/tl-operators.c
+++ b/test/t-language/tl-operators.c
@@ -86,7 +86,7 @@ nosave mixed *tests = ({
     ({ "bitwise left shift assignment (int, >MAX_SHIFT)", 0,
        (: int i = 1;
           i<<=10000;
-          return i == -__INT_MAX__-1; :)
+          return i == 0; :)
     }),
     ({ "bitwise left shift assignment (char)", 0,
        (: string s = "0"; // 48
@@ -123,6 +123,35 @@ nosave mixed *tests = ({
        (: string s = "0"; // 48
           s[0] >>= 10000;
           return s[0] == 0; :)
+    }),
+    ({ "bitwise right shift assignment (negative int, >MAX_SHIFT)", 0,
+       (: int i = -8;
+          i>>=10000;
+          return i == -1; :)
+    }),
+    /* The assigning shift operators must agree with their plain
+     * counterparts for every combination of value and shift width.
+     */
+    ({ "shift assignment matches plain shift", 0,
+       (: foreach (int x : ({ 1, -1, -8, 255, __INT_MAX__, __INT_MIN__ }))
+            foreach (int n : ({ 0, 1, 31, 63, 64, 65, 10000, __INT_MAX__ }))
+            {
+                int i;
+                i = x; i <<= n;  if (i != (x << n))  return 0;
+                i = x; i >>= n;  if (i != (x >> n))  return 0;
+                i = x; i >>>= n; if (i != (x >>> n)) return 0;
+            }
+          return 1; :)
+    }),
+    ({ "shift assignment on a mapping entry", 0,
+       (: mapping m = ([ "v": -8 ]);
+          m["v"] >>= 10000;
+          return m["v"] == -1; :)
+    }),
+    ({ "shift assignment on an array element", 0,
+       (: int *a = ({ -8 });
+          a[0] >>= 10000;
+          return a[0] == -1; :)
     }),
     ({ "logical right shift (positive)", 0,
        (: return (2147483647 >>> 20) == 2047; :)


### PR DESCRIPTION
`F_LSH_EQ` and `F_RSH_EQ` clamp the shift width before using it:

```c
        if (shift > MAX_SHIFT)
            shift = MAX_SHIFT;            /* F_LSH_EQ */

        if (shift > MAX_SHIFT)
            shift = MAX_SHIFT + 1;        /* F_RSH_EQ */
```

The plain operators do not, so the two disagree once all bits are shifted out:

| expression | `op=` | `op` |
|---|---|---|
| `1 <<= 64` | -9223372036854775808 | 0 |
| `1 <<= 1000` | -9223372036854775808 | 0 |
| `-8 >>= 64` | 0 | -1 |
| `-1 >>= 100` | 0 | -1 |

`x <<= n` silently produces `x << 63` instead of 0, and `x >>= n` drops the sign that
the arithmetic right shift is supposed to preserve. It applies to every lvalue kind -
plain variables, mapping entries, array elements.

`F_RSHL_EQ` (`>>>=`) already does it correctly: no pre-clamp, only the check at the
point of use. That is the pattern this patch applies to the other two.

## Why this is a leftover and not a deliberate difference

The current code contains the correct handling twice over, unreachable:

```c
            case LVALUE_UNPROTECTED_CHAR:
                    val = assign_unprotected_char(shift > MAX_SHIFT ? 0 : (val << shift));
        ...
        case T_NUMBER:
                if (shift > MAX_SHIFT)
                    argp->u.number = 0;
                else
                    argp->u.number <<= shift;
```

Both branches say "shifting out all bits yields 0", and the clamp at the top of the
case makes both impossible to reach. The history shows how that happened:

- the divergence exists since at least 2011, when the operators were separate pieces
  of code (`F_LSH` returned 0, `F_LSH_EQ` clamped)
- 3b26ccce (2016, "Overhauled the lvalue handling") hoisted the clamp to the top of
  the case; the use site was a plain `argp->u.number <<= shift`
- 81abe1be (2018, "Implemented Unicode support for operators and efuns") added the
  `shift > MAX_SHIFT` handling shown above at the use site and in the char branch -
  but left the 2016 clamp in place, so the new code became dead

So the intent to return 0 is in the tree twice; only the leftover clamp prevents it.

The documentation agrees: doc/LPC/operators describes `var <<= expr` in the same group
as `var += expr`, which is documented as "mostly equivalent to var = var + expr".

## Fix

Drop both clamps. `F_LSH_EQ` then reaches the existing `shift > MAX_SHIFT` handling,
which already matches `F_LSH`. For `F_RSH_EQ` the use site needed the sign handling
that `F_RSH` has, since returning a flat 0 is wrong for negative values:

```c
                if (shift <= MAX_SHIFT)
                    argp->u.number >>= shift;
                else if (argp->u.number >= 0)
                    argp->u.number = 0;
                else
                    argp->u.number = -1;
```

The char branches need no change - a char is a non-negative codepoint, and
`F_RSHL_EQ` already notes that chars are treated as unsigned.

## This changes an existing test case

`test/t-language/tl-operators.c` asserted the old behaviour:

```lpc
    ({ "bitwise left shift assignment (int, >MAX_SHIFT)", 0,
       (: int i = 1;
          i<<=10000;
          return i == -__INT_MAX__-1; :)
    }),
```

I changed it to expect 0. Flagging it explicitly since silently rewriting a test is
exactly the wrong move if the old value was intentional.

I do not believe it was. That test was added in c4f2fdbd (2011) together with the one
directly above it, which asserts `(1 << 10000) == 0` - so the same commit records both
halves of the inconsistency, which reads like the author capturing what the driver did
rather than specifying what it should do. The file is internally inconsistent on the
same point too: `s[0] <<= 10000` is asserted to be 0, the unclamped answer (it passes
either way, since `48 << 63` overflows to 0).

If you would rather keep `<<=` and `>>=` as they are, this patch should be dropped
rather than adjusted - the point of it is only that the two forms should agree.

## Testing

Added to tl-operators.c next to the existing shift tests: a negative right shift past
MAX_SHIFT, a loop comparing all three assigning shifts against their plain
counterparts over 6 values x 8 shift widths, and the mapping-entry and array-element
lvalue variants. Six of the seven new/changed cases fail without the patch; `>>>=`
passes either way, as expected.

Full suite: no failures. Note that the suite intermittently reports "Found lost block
during garbage collection" in the `after-*` type tests - that happens on unmodified
master as well (once in three runs here) and is unrelated to this change. Also run
under `-fsanitize=address,undefined` with nothing reported in interpret.c.