### PR TITLE
slaballoc: don't divide by zero in the extended statistics

### DIFF
--- a/src/slaballoc.c
+++ b/src/slaballoc.c
@@ -1251,8 +1251,11 @@ mem_dump_extdata (strbuf_t *sbuf)
              * as mem_alloc() does it.
              */
                 unsigned long numObjects = getNumBlocks(i);
-                unsigned long avgNumObjects = extstats[i].cur_alloc
-                                              / (slabtable[i].numSlabs - slabtable[i].numFreeSlabs);
+                unsigned long numUsedSlabs = slabtable[i].numSlabs
+                                             - slabtable[i].numFreeSlabs;
+                unsigned long avgNumObjects = numUsedSlabs
+                                              ? extstats[i].cur_alloc / numUsedSlabs
+                                              : 0;
 
                 strbuf_addf(sbuf, "            "
                                   "Avg. %4lu of %4lu (%6.2lf%%) objects per slab allocated\n"

--- a/test/t-efuns.c
+++ b/test/t-efuns.c
@@ -11,6 +11,7 @@
 #include "/sys/commands.h"
 #include "/sys/configuration.h"
 #include "/sys/driver_hook.h"
+#include "/sys/driver_info.h"
 #include "/sys/functionlist.h"
 #include "/sys/input_to.h"
 #include "/sys/lpctypes.h"
@@ -1953,6 +1954,18 @@ mixed *tests = (this_object() == blueprint()) &&
         (: db_conv_string("ldmud") == "ldmud" :) // This shouldn't crash.
     }),
 #endif // __MYSQL__
+
+    ({ "driver_info status texts", 0,
+        (: foreach (int what: ({ DI_STATUS_TEXT_MEMORY, DI_STATUS_TEXT_TABLES,
+                                 DI_STATUS_TEXT_SWAP, DI_STATUS_TEXT_MALLOC,
+                                 DI_STATUS_TEXT_MALLOC_EXTENDED }))
+           {
+               mixed s = driver_info(what);
+               if (!stringp(s) && s != 0)
+                   return 0;
+           }
+           return 1; :)
+    }),
 
 #ifdef __TLS__
 }) + (tls_available() ? ({

--- a/test/t-malloc-extstats.c
+++ b/test/t-malloc-extstats.c
@@ -1,0 +1,32 @@
+#include "/inc/base.inc"
+#include "/sys/driver_info.h"
+
+/* Regression test: with MALLOC_EXT_STATISTICS the slab allocator's
+ * mem_dump_extdata() divided by the number of used slabs of each size
+ * class without checking for zero. Freshly booted, some size classes
+ * have no slabs at all, so this crashed with SIGFPE.
+ *
+ * This test must run in a fresh driver (not from t-efuns.c), because a
+ * busy driver may have used every size class already.
+ */
+
+string *epilog(int eflag)
+{
+    mixed s;
+
+    msg("\nRunning test for driver_info(DI_STATUS_TEXT_MALLOC_EXTENDED):\n"
+          "--------------------------------------------------------------\n");
+
+    s = driver_info(DI_STATUS_TEXT_MALLOC_EXTENDED);
+    if (stringp(s) || s == 0)
+    {
+        msg("Success.\n");
+        shutdown(0);
+    }
+    else
+    {
+        msg("FAILURE: unexpected result %O.\n", s);
+        shutdown(1);
+    }
+    return 0;
+}


### PR DESCRIPTION
`mem_dump_extdata()` computes the average number of allocated objects per
used slab as

```c
unsigned long avgNumObjects = extstats[i].cur_alloc
                              / (slabtable[i].numSlabs - slabtable[i].numFreeSlabs);
```

without checking the divisor. A size class whose slabs are all free — or
that has no slabs at all, which is the state of every size class that has
never been used — makes this an integer division by zero, and the driver
dies with SIGFPE.

In a build with `MALLOC_EXT_STATISTICS` this makes
`driver_info(DI_STATUS_TEXT_MALLOC_EXTENDED)` (and the equivalent
`status malloc extstats` command) a reliable one-line driver killer:

```c
driver_info(DI_STATUS_TEXT_MALLOC_EXTENDED);   /* SIGFPE */
```

Freshly booted with the test mudlib, two of the sixteen small block size
classes (13 and 15) have no slabs yet — verified by instrumenting the
divisor — so the very first call crashes. A driver that has been running
for a while can hit the same division through the other route: after a
garbage collection, size classes whose remaining slabs all became free
again (`numSlabs == numFreeSlabs`, with `SLAB_RETENTION_TIME` keeping
them cached).

## Fix

Compute the number of used slabs once and report an average of zero when
there are none:

```c
unsigned long numUsedSlabs = slabtable[i].numSlabs
                             - slabtable[i].numFreeSlabs;
unsigned long avgNumObjects = numUsedSlabs
                              ? extstats[i].cur_alloc / numUsedSlabs
                              : 0;
```

A class without used slabs has no allocated objects, so zero is the
truthful value, and the printed line keeps its format. The percentage in
the same line divides by `getNumBlocks(i)` as a double, which cannot be
zero.

I checked the remaining divisions in the statistics code: the per-second
averages are guarded by the `num_update_calls` ternary, and
`mem_update_stats()` returns early unless `time_diff > 0`. This was the
only unguarded one.

## Alternatives considered

- **Skip the "Avg." line entirely for unused size classes.** Slightly
  less output, but it changes the shape of the report, which tools and
  humans may be parsing, and hides the (useful) information that the
  class exists and is empty. Printing an average of 0 of N objects keeps
  the format stable.
- **Clamp the divisor to 1.** One branch less, same output for the
  0-slabs case (0/1 = 0), but it silently miscomputes the average for the
  hypothetical case of a nonzero `cur_alloc` with no used slabs instead
  of making it visible - and it reads like an accident, not a decision.

## Tests

A new standalone test `test/t-malloc-extstats.c` queries the extended
statistics from a freshly booted driver. It has to be standalone rather
than a case in `t-efuns.c`: by the time the main suite reaches any test
case, every size class has been used already and the division never sees
a zero — I verified that an in-suite test case does *not* catch the bug.
Freshly booted it is deterministic: without the fix the test dies with
SIGFPE, with the fix it passes.

Also adds a smoke test to `t-efuns.c` that calls all five
`DI_STATUS_TEXT_*` variants; on non-slaballoc or non-extended builds the
tests degrade gracefully (the efun then returns a string or 0 as well).

The full test suite passes in a normal build and in an ASan/UBSan build;
the sanitizers report nothing from `slaballoc.c`.