### PR TITLE
xalloc: check the hard malloc limit before allocating, not after

### DIFF
--- a/src/xalloc.c
+++ b/src/xalloc.c
@@ -570,17 +570,27 @@ retry_alloc (size_t size MTRACE_DECL)
 
 /*-------------------------------------------------------------------------*/
 static INLINE Bool
-check_max_malloced (void)
+check_max_malloced_addition (size_t addition)
 
-/* If max_malloced is set, check if the allocated memory exceeds it.
+/* If max_malloced is set, check if the allocated memory would exceed it
+ * after <addition> more bytes have been allocated.
  * If not, return FALSE.
  * If yes, and malloc_privilege < MALLOC_SYSTEM: return TRUE.
  * If yes, and malloc_privilege == MALLOC_SYSTEM: abort.
+ *
+ * The check has to happen before the allocation: afterwards the caller
+ * can no longer be told "nothing happened", which is what a NULL result
+ * means to it.
  */
 
 {
 #ifndef NO_MEM_BLOCK_SIZE
-    if (max_malloced > 0 && (mp_int)xalloc_stat.size > max_malloced)
+    /* The comparison is written so that it cannot overflow: <addition>
+     * comes from a caller-supplied size and may be arbitrarily large.
+     */
+    if (max_malloced > 0
+     && (addition > (size_t)max_malloced
+      || xalloc_stat.size > (size_t)max_malloced - addition))
     {
         static const char mess[] = "HARD_MALLOC_LIMIT reached.\n";
         writes(2, mess);
@@ -594,9 +604,11 @@ check_max_malloced (void)
         fatal("Out of memory.\n");
         /* NOTREACHED */
     }
+#else
+    (void)addition;
 #endif
     return MY_FALSE;
-} /* check_max_malloced() */
+} /* check_max_malloced_addition() */
 
 /*-------------------------------------------------------------------------*/
 void *
@@ -627,6 +639,14 @@ xalloc_traced (size_t size MTRACE_DECL)
 #endif /* MALLOC_SBRK_TRACE */
 
     size += XM_OVERHEAD_SIZE + sizeof(word_t)*VALGRIND_REDZONE;
+
+#ifndef NO_MEM_BLOCK_SIZE
+    /* Check the limit before allocating: a block that has been allocated
+     * cannot be un-allocated without the caller noticing.
+     */
+    if (check_max_malloced_addition(size))
+        return NULL;
+#endif
 
     do {
         p = mem_alloc(size);
@@ -670,8 +690,6 @@ xalloc_traced (size_t size MTRACE_DECL)
     count_up(&xalloc_stat, XM_OVERHEAD_SIZE);
 #else
     count_up(&xalloc_stat, mem_block_size(p));
-    if (check_max_malloced())
-        return NULL;
 #endif
     return (void *)(p + XM_OVERHEAD);
 } /* xalloc_traced() */
@@ -819,6 +837,13 @@ rexalloc_traced (void * p, size_t size MTRACE_DECL
     if (old_size >= size)
         return p;
 
+    /* Check the limit before growing the block: on a limit hit we must
+     * leave <p> untouched, because that is what a NULL result promises
+     * the caller.
+     */
+    if (check_max_malloced_addition(size - old_size))
+        return NULL;
+
     t = mem_increment_size(block, size - old_size);
     if (t)
     {
@@ -826,8 +851,6 @@ rexalloc_traced (void * p, size_t size MTRACE_DECL
 
         count_back(&xalloc_stat, old_size);
         count_up(&xalloc_stat, mem_block_size(block));
-        if (check_max_malloced())
-            return NULL;
 
         /* Additional bytes if we round up to full words. */
         size_t remainder = ((size + sizeof(word_t) - 1) & ~(sizeof(word_t) - 1)) - size;
@@ -855,8 +878,6 @@ rexalloc_traced (void * p, size_t size MTRACE_DECL
 #ifndef NO_MEM_BLOCK_SIZE
         count_back(&xalloc_stat, old_size);
         count_up(&xalloc_stat, mem_block_size(t));
-        if (check_max_malloced())
-            return NULL;
 #endif
         t += XM_OVERHEAD;
         if (p == t)

--- a/test/t-malloc-limit.c
+++ b/test/t-malloc-limit.c
@@ -1,0 +1,63 @@
+#include "/inc/base.inc"
+#include "/sys/configuration.h"
+#include "/sys/driver_info.h"
+
+/* Regression test: hitting the hard malloc limit must raise a normal LPC
+ * error and leave the driver usable.
+ *
+ * xalloc()/rexalloc() used to check the limit only after the allocation
+ * had been made, and then returned NULL: for xalloc() the block was
+ * allocated, counted and never freed (a leak), for rexalloc() the old
+ * block had already been freed by mem_realloc(), so the caller was left
+ * holding a dangling pointer.
+ */
+
+string grow_string()
+{
+    string s = "x";
+    for (int i = 0; i < 30; i++)
+        s = s + s;
+    return s;
+}
+
+string *epilog(int eflag)
+{
+    int used, before, after;
+    mixed err;
+
+    msg("\nRunning test for the hard malloc limit:\n"
+          "----------------------------------------\n");
+
+    used = driver_info(DI_SIZE_MEMORY_USED);
+    configure_driver(DC_MEMORY_LIMIT, ({ 0, used + 100000 }));
+
+    before = driver_info(DI_SIZE_MEMORY_USED);
+    for (int i = 0; i < 10; i++)
+        err = catch(grow_string(); nolog);
+    after = driver_info(DI_SIZE_MEMORY_USED);
+
+    configure_driver(DC_MEMORY_LIMIT, ({ 0, 0 }));
+
+    msg("error: %O\n", err);
+    msg("used before: %d, after 10 failed allocations: %d (%+d)\n"
+       , before, after, after - before);
+
+    if (!stringp(err))
+    {
+        msg("FAILURE: expected an error.\n");
+        shutdown(1);
+        return 0;
+    }
+
+    /* The driver must still be usable afterwards. */
+    if (sizeof(allocate(1000)) != 1000)
+    {
+        msg("FAILURE: driver not usable after the limit was hit.\n");
+        shutdown(1);
+        return 0;
+    }
+
+    msg("Success.\n");
+    shutdown(0);
+    return 0;
+}


### PR DESCRIPTION
`xalloc()` and `rexalloc()` call `check_max_malloced()` *after* the block has
already been allocated, and return NULL when the limit is hit. NULL means
"nothing happened" to every caller, but by then something had:

- **`xalloc_traced()`** — the block is allocated and counted, but neither freed
  nor counted back. Every refused allocation leaks, and — worse —
  `xalloc_stat.size` stays above the limit, so every *following* allocation is
  refused as well. The driver never recovers.
- **`rexalloc_traced()`** — `mem_realloc()` has already freed the old block.
  The caller follows the `realloc()` convention and keeps using (or frees) its
  old pointer, which is now dangling. `closure.c`'s `realloc_code()` does
  exactly that: on NULL it calls `lambda_error()`, which does
  `xfree(current.code)` on the block `mem_realloc()` just freed.
- **the in-place growth path** (`mem_increment_size()`) — the block has been
  grown and the statistics updated, but the caller is told it failed.

The hard limit is reachable from LPC through
`configure_driver(DC_MEMORY_LIMIT, ...)`, and normal LPC execution runs with
`MALLOC_USER` privilege, so `check_max_malloced()` returns TRUE rather than
aborting.

## Reproduction

```c
int used = driver_info(DI_SIZE_MEMORY_USED);
configure_driver(DC_MEMORY_LIMIT, ({ 0, used + 100000 }));
string s = "x";
for (int i = 0; i < 30; i++) s = s + s;     /* inside catch() */
```

On master the driver logs

```
(catch) Out of memory detected.
Error in master_ob->epilog()
LDMud ready for users.
```

and keeps running with a permanently poisoned allocation count. The error is
*not* catchable even though it happens inside `catch()`: the leaked blocks keep
the limit exceeded, so the error handling cannot allocate either, the reserves
are consumed, `out_of_memory` is set, and `catch()` deliberately rethrows
(`simulate.c:452`). A single refused allocation is enough.

With the fix the same code raises a normal, catchable
`Out of memory (131072 bytes)` error, the allocation count is unchanged
(measured: +752 bytes after ten refused allocations, i.e. ordinary test
noise, versus a runaway count on master), and the driver keeps working.

## Fix

Check the limit *before* the allocation. Then a refusal really is "nothing
happened": no block is allocated, no block is freed, the statistics are
unchanged, and the `realloc()` convention holds for `rexalloc()`.

The comparison is written without forming the sum:

```c
if (max_malloced > 0
 && (addition > (size_t)max_malloced
  || xalloc_stat.size > (size_t)max_malloced - addition))
```

so that a caller-supplied size cannot overflow it — `xalloc_stat.size + size`
would have been undefined behaviour for a large enough request, and the tree
is built with UBSan in CI.

The check now uses the requested size rather than `mem_block_size()` of the
finished block, so it can be off by the allocator's rounding and per-block
overhead — a few words per allocation. That seemed clearly preferable to the
alternative of being exact but unable to honour the result.

## Alternatives considered

- **Undo the allocation on a limit hit** (`mem_free()` + `count_back()` in
  `xalloc()`). That fixes the leak exactly, with no rounding approximation.
  But it cannot fix `rexalloc()`: once `mem_realloc()` has freed and moved the
  old block there is nothing to undo, and the caller's pointer is already
  invalid. A fix that has to be different in the two functions for no reason
  visible to the reader is worse than one rule applied in both.
- **Return the block anyway and only warn.** Keeps every caller happy but
  makes the "hard" limit advisory, which defeats its purpose.
- **Have `rexalloc()` allocate-copy-free by hand** so it can bail out before
  freeing. That is what `mem_realloc()` already does internally, only slower
  and duplicated.

## Tests

A new standalone test `test/t-malloc-limit.c` sets a hard limit just above the
current allocation, provokes the failure ten times, and checks that

- the error is catchable,
- the reported allocation does not run away,
- the driver is still usable afterwards (`allocate(1000)`).

It has to be standalone because it changes a global driver setting. With the
fix it passes; without it the driver hangs after the first failed allocation
and the test times out, so it is a genuine counter-test rather than one that
merely reports a different value.

The full test suite passes in a normal build and in an ASan/UBSan build; the
sanitizers report nothing from `xalloc.c`.

## Related findings, not part of this PR

While reproducing this I hit two caller-side bugs that survive this fix,
because they are about how callers handle a failed allocation. I would rather
send them separately than mix three things into one PR; say the word if you
prefer them here.

1. **`closure.c`: `lambda_error()` frees one svalue too many.**
   `insert_value_push()` does `if (--current.values_left < 0) realloc_values();`,
   so inside `realloc_values()` the counter is already `-1`. When the
   allocation fails, `lambda_error()` computes
   `num_values = current.value_max - current.values_left` and frees that many
   svalues starting at `current.valuep` — one past the end of the array.
   Instrumented: `value_max=1024, values_left=-1, num=1025, valuep==values`.
   The result is `(free_svalue) Illegal svalue ... type 4099` and `fatal()`.

2. **`interpret.c`: NULL dereference on a failed mapping lvalue.** Assigning
   into a mapping under memory pressure
   (`mapping m = ([:1]); for (...) m[i] = i;` with the limit set) crashes in
   `inl_transfer_svalue()` reading through the NULL that `get_map_lvalue()`
   returned.