### PR TITLE
closure: keep .valuep and .values_left in sync while growing the value block

### DIFF
--- a/src/closure.c
+++ b/src/closure.c
@@ -1364,9 +1364,12 @@ realloc_values (void)
 
 /* Double the size of the value block in the current workspace.
  * The function is called only when all values in the current block
- * have been assigned.
+ * have been assigned, i.e. with .values_left == 0.
  *
- * Raise an error when out of memory.
+ * Raise an error when out of memory. The caller must not have taken
+ * the new entry out of .values_left yet: on error lambda_error() walks
+ * the assigned values, and for that .valuep and .values_left have to
+ * agree (.valuep == .values + .values_left).
  */
 
 {
@@ -1377,9 +1380,8 @@ realloc_values (void)
 
     new_values = xalloc(new_max * sizeof(*new_values));
     if (!new_values)
-        lambda_error("Out of memory (%"PRIdMPINT
-                     " bytes) for %"PRIdMPINT" new values\n",
-                     new_max, new_max * sizeof(*new_values));
+        lambda_error("Out of memory (%"PRIdMPINT" bytes) for new values\n",
+                     (mp_int)(new_max * sizeof(*new_values)));
 
     current.values_left += current.value_max;
     memcpy( (current.valuep = new_values + current.value_max)
@@ -1703,8 +1705,9 @@ insert_value_push (svalue_t *value)
     else
         lambda_error("Too many values in lambda()\n");
 
-    if (--current.values_left < 0)
+    if (current.values_left <= 0)
         realloc_values();
+    current.values_left--;
 
     /* Don't forget to copy the value itself */
     assign_svalue_no_free(--current.valuep, value);
@@ -3865,8 +3868,9 @@ compile_value (svalue_t *value, enum compile_value_input_flags opt_flags)
                                     );
                                 }
 
-                                if (--current.values_left < 0)
+                                if (current.values_left <= 0)
                                     realloc_values();
+                                current.values_left--;
                                 no_string = MY_FALSE;
                                 stmp.type = rlabel->type;
                                 stmp.u.str = make_tabled_from(rlabel->u.str);

--- a/test/t-lambda-oom.c
+++ b/test/t-lambda-oom.c
@@ -1,0 +1,52 @@
+#include "/inc/base.inc"
+#include "/sys/configuration.h"
+#include "/sys/driver_info.h"
+
+/* Regression test: when realloc_values() cannot grow the value block,
+ * lambda_error() used to free one svalue more than had been assigned,
+ * because insert_value_push() had already taken the new entry out of
+ * .values_left. The result was a fatal "Illegal svalue".
+ *
+ * The hard memory limit is swept over a range so that the growth of the
+ * value block fails somewhere in it regardless of the exact allocation
+ * sizes of the build. The test insists on having seen that failure, so
+ * it cannot pass by never reaching the code path at all.
+ */
+
+string *epilog(int eflag)
+{
+    mixed prog = ({ #', });
+    int seen = 0;
+
+    msg("\nRunning test for lambda() cleanup after a failed allocation:\n"
+          "-------------------------------------------------------------\n");
+
+    for (int i = 0; i < 200; i++)
+        prog += ({ "v" + i });
+
+    for (int margin = 2400; margin <= 4200; margin += 100)
+    {
+        int used = driver_info(DI_SIZE_MEMORY_USED);
+        mixed err;
+
+        configure_driver(DC_MEMORY_LIMIT, ({ 0, used + margin }));
+        err = catch(lambda(0, prog); nolog);
+        configure_driver(DC_MEMORY_LIMIT, ({ 0, 0 }));
+
+        if (stringp(err) && strstr(err, "for new values") >= 0)
+            seen++;
+    }
+
+    msg("value block growth failed cleanly %d times.\n", seen);
+
+    if (!seen)
+    {
+        msg("FAILURE: never reached the failing growth - test is not testing anything.\n");
+        shutdown(1);
+        return 0;
+    }
+
+    msg("Success.\n");
+    shutdown(0);
+    return 0;
+}


### PR DESCRIPTION
`insert_value_push()` takes the new entry out of `.values_left` *before* it makes
room for it:

```c
if (--current.values_left < 0)
    realloc_values();
assign_svalue_no_free(--current.valuep, value);
```

so inside `realloc_values()` the counter is already `-1` while `.valuep` still
points at the first assigned value. The success path is written to account for
that, but the error path is not: when the allocation fails, `lambda_error()`
computes

```c
mp_int num_values = current.value_max - current.values_left;
for (svp = current.valuep; --num_values >= 0; )
    free_svalue(svp++);
```

and frees one svalue more than has been assigned — one past the end of the
block. Instrumented at the moment of failure:

```
value_max=1024  values_left=-1  num_values=1025  .valuep == .values
```

Whatever follows the block is then interpreted as an svalue and freed. The
driver dies with `(free_svalue) Illegal svalue ... type <garbage>`; I have seen
types 96, 134, 4099 and 13617 in different runs, so it depends on the heap
contents and is not a benign misread.

## Reproduction

Reachable from LPC through the hard memory limit, which makes the allocation in
`realloc_values()` fail:

```c
mixed prog = ({ #', });
for (int i = 0; i < 200; i++) prog += ({ "v" + i });

int used = driver_info(DI_SIZE_MEMORY_USED);
configure_driver(DC_MEMORY_LIMIT, ({ 0, used + 2500 }));
catch(lambda(0, prog); nolog);
```

On master this kills the driver. With the fix the same code raises the ordinary
catchable `Out of memory (1024 bytes) for new values` and execution continues.

## Fix

Check the counter *before* taking the entry, the way the code buffer has always
done it (`if (current.code_left < n) realloc_code(); current.code_left -= n;`),
so that the invariant `.valuep == .values + .values_left` holds at every point
at which an error can be raised.

`realloc_values()` itself needs no change. It is now entered with
`.values_left == 0` instead of `-1`, and its existing arithmetic
(`values_left += value_max`, `valuep = new_values + value_max`) produces exactly
the same state as before — I checked this case by case rather than assuming it.
Its comment now states the precondition and why it matters.

The second site that grows the value block, the string label in the `#'switch`
compiler, has the identical pattern and gets the identical treatment.

## The error message of that same failure

While confirming which allocation had failed I noticed the message is wrong:

```c
lambda_error("Out of memory (%"PRIdMPINT" bytes) for %"PRIdMPINT" new values\n",
             new_max, new_max * sizeof(*new_values));
```

`lambda_error()` documents and implements "0 or 1 extra argument" — it does
`errorf(error_str, va_arg(va, char *))` — so the second specifier is filled from
an argument that was never passed, and the one that does arrive is the entry
count printed as a byte count. The observed output was
`Out of memory (2048 bytes) for 0 new values`, where 2048 was the number of
entries and 0 was garbage. It is the only `lambda_error()` call in the file that
passes two arguments. Since it is the message of the very failure this PR is
about, I fixed it here: report the byte count, in the same shape as the
neighbouring messages.

## Alternatives considered

- **Restore the counter in `realloc_values()` before calling `lambda_error()`**
  (`current.values_left++;` on the failure path). One line, but it leaves the
  invariant broken during the call and only patches up the one exit that
  happens to exist today — the next error raised inside that window would have
  the same problem. It also hides the coupling in the callee rather than fixing
  it where it is created.
- **Make `lambda_error()` defensive**, e.g. clamp `num_values` to the block
  size. That treats a symptom, and a clamp would silently paper over a real
  inconsistency if one ever appeared for a different reason.
- **Leave the message alone** and send it separately. It is two lines in the
  same error path, and reporting a garbage value in an out-of-memory message
  makes exactly this class of bug harder to diagnose, so it seemed worth
  keeping together. Happy to split it out if you prefer.

## Tests

`test/t-lambda-oom.c` sweeps the hard memory limit across a range in which the
growth of the value block fails, and **insists on having seen that failure**
(`seen > 0`), so it cannot pass by never reaching the code path — that check is
there because an earlier version of the test did exactly that and looked green.

It has to be standalone rather than a case in `t-efuns.c` because it changes a
global driver setting.

- Without the fix, the driver dies on the first hit of the range.
- With the fix, 19 failures in the swept range are reported and handled
  cleanly, and the run finishes.

The full test suite passes in a normal build and in an ASan/UBSan build; the
sanitizers report nothing from `closure.c`.

The swept range is deliberately narrow. A wider sweep also drives the driver
into allocation failures whose *cleanup* cannot allocate either, which is the
separate problem in #142 — with that PR applied a sweep of 2000..6000 passes
here as well (37 clean failures). The range chosen keeps this test independent
of #142.