### PR TITLE
interpret: check the result of get_map_lvalue()

### DIFF
--- a/src/efuns.c
+++ b/src/efuns.c
@@ -8132,6 +8132,12 @@ convert_to_type (svalue_t *dest, svalue_t *src, lpctype_t *type, struct_t *opts,
                 {
                     svalue_t key = svalue_string(st->type->member[i].name);
                     svalue_t *entry = get_map_lvalue_unchecked(m, &key);
+                    if (!entry)
+                    {
+                        free_mapping(m);
+                        outofmemory("converted mapping entry");
+                        /* NOTREACHED */
+                    }
                     free_svalue(entry);
                     assign_rvalue_no_free(entry, &st->member[i]);
                 }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2761,7 +2761,12 @@ link_protected_lvalue (svalue_t *dest, svalue_t *lv)
             /* We create the entry and assign <lv>. */
             struct protected_mapentry_lvalue *e = dest->u.protected_mapentry_lvalue;
             svalue_t *val = get_map_lvalue(e->map, &(e->key));
-            svalue_t temp = *dest;
+            svalue_t temp;
+
+            if (val == NULL)
+                errorf("Out of memory when creating mapping entry.\n");
+
+            temp = *dest;
 
             /* Copy the lvalue into mapping. */
             assert(val->type == T_NUMBER && val->u.number == 0);
@@ -2864,6 +2869,31 @@ link_protected_lvalue (svalue_t *dest, svalue_t *lv)
 } /* link_protected_lvalue */
 
 /*-------------------------------------------------------------------------*/
+static INLINE svalue_t *
+get_current_mapentry_lvalue (void)
+
+/* Create the entry described by <current_unprotected_mapentry> and return
+ * a pointer to its first value. The caller adds .index to address the
+ * column it wants.
+ *
+ * The key is released in either case. If the entry could not be created
+ * because the driver is out of memory, an error is raised - the callers
+ * have no way to represent a missing entry.
+ */
+
+{
+    svalue_t *entry = get_map_lvalue(current_unprotected_mapentry.map
+                                    , &(current_unprotected_mapentry.key));
+
+    free_svalue(&(current_unprotected_mapentry.key));
+
+    if (entry == NULL)
+        errorf("Out of memory when creating mapping entry.\n");
+
+    return entry;
+} /* get_current_mapentry_lvalue() */
+
+/*-------------------------------------------------------------------------*/
 void
 assign_svalue (svalue_t *dest, svalue_t *v)
 
@@ -2939,13 +2969,11 @@ assign_svalue (svalue_t *dest, svalue_t *v)
         case LVALUE_UNPROTECTED_MAPENTRY:
             {
                 /* We create the entry to assign to. */
-                svalue_t *val = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key));
+                svalue_t *val = get_current_mapentry_lvalue();
 
                 /* The entry should not have existed. */
                 assert(val->type == T_NUMBER && val->u.number == 0);
                 dest = val + current_unprotected_mapentry.index;
-
-                free_svalue(&(current_unprotected_mapentry.key));
                 break;
             }
 
@@ -3027,7 +3055,12 @@ assign_svalue (svalue_t *dest, svalue_t *v)
             {
                 /* Let's create the entry if it doesn't exist already. */
                 struct protected_mapentry_lvalue *e = dest->u.protected_mapentry_lvalue;
-                dest = get_map_lvalue(e->map, &(e->key)) + e->index;
+                svalue_t *val = get_map_lvalue(e->map, &(e->key));
+
+                if (val == NULL)
+                    errorf("Out of memory when creating mapping entry.\n");
+
+                dest = val + e->index;
                 continue;
             }
 
@@ -3210,13 +3243,11 @@ inl_transfer_svalue (svalue_t *dest, svalue_t *v)
         case LVALUE_UNPROTECTED_MAPENTRY:
             {
                 /* We create the entry to transfer to. */
-                svalue_t *val = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key));
+                svalue_t *val = get_current_mapentry_lvalue();
 
                 /* The entry should not have existed. */
                 assert(val->type == T_NUMBER && val->u.number == 0);
                 dest = val + current_unprotected_mapentry.index;
-
-                free_svalue(&(current_unprotected_mapentry.key));
                 break;
             }
 
@@ -3299,7 +3330,12 @@ inl_transfer_svalue (svalue_t *dest, svalue_t *v)
             else
             {
                 struct protected_mapentry_lvalue *e = dest->u.protected_mapentry_lvalue;
-                dest = get_map_lvalue(e->map, &(e->key)) + e->index;
+                svalue_t *val = get_map_lvalue(e->map, &(e->key));
+
+                if (val == NULL)
+                    errorf("Out of memory when creating mapping entry.\n");
+
+                dest = val + e->index;
                 continue;
             }
 
@@ -4286,8 +4322,7 @@ add_number_to_lvalue (char* op, svalue_t *dest, int i, svalue_t *pre, svalue_t *
             }
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                dest = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                dest = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
 
             case LVALUE_PROTECTED:
@@ -4310,7 +4345,12 @@ add_number_to_lvalue (char* op, svalue_t *dest, int i, svalue_t *pre, svalue_t *
             case LVALUE_PROTECTED_MAPENTRY:
             {
                 struct protected_mapentry_lvalue *e = dest->u.protected_mapentry_lvalue;
-                dest = get_map_lvalue(e->map, &(e->key)) + e->index;
+                svalue_t *val = get_map_lvalue(e->map, &(e->key));
+
+                if (val == NULL)
+                    errorf("Out of memory when creating mapping entry.\n");
+
+                dest = val + e->index;
                 continue;
             }
         } /* switch() */
@@ -14326,8 +14366,7 @@ again:
                 break; /* NOTREACHED */
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                argp = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                argp = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
 
             case LVALUE_UNPROTECTED_MAP_RANGE:
@@ -14656,8 +14695,7 @@ again:
                 break; /* NOTREACHED */
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                argp = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                argp = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
 
             case LVALUE_UNPROTECTED_MAP_RANGE:
@@ -14942,8 +14980,7 @@ again:
                 break; /* NOTREACHED */
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                argp = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                argp = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
 
             case LVALUE_UNPROTECTED_MAP_RANGE:
@@ -15236,8 +15273,7 @@ again:
             }
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                argp = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                argp = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
         }
 
@@ -15401,8 +15437,7 @@ again:
             }
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                argp = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                argp = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
         }
 
@@ -15505,8 +15540,7 @@ again:
                 break; /* NOTREACHED */
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                argp = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                argp = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
 
             case LVALUE_UNPROTECTED_MAP_RANGE:
@@ -15700,8 +15734,7 @@ again:
                 break; /* NOTREACHED */
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                argp = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                argp = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
 
             case LVALUE_UNPROTECTED_MAP_RANGE:
@@ -15838,8 +15871,7 @@ again:
                 break; /* NOTREACHED */
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                argp = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                argp = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
 
             case LVALUE_UNPROTECTED_MAP_RANGE:
@@ -15967,8 +15999,7 @@ again:
             }
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                argp = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                argp = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
         }
 
@@ -16072,8 +16103,7 @@ again:
             }
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                argp = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                argp = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
         }
 
@@ -16177,8 +16207,7 @@ again:
             }
 
             case LVALUE_UNPROTECTED_MAPENTRY:
-                argp = get_map_lvalue(current_unprotected_mapentry.map, &(current_unprotected_mapentry.key)) + current_unprotected_mapentry.index;
-                free_svalue(&(current_unprotected_mapentry.key));
+                argp = get_current_mapentry_lvalue() + current_unprotected_mapentry.index;
                 break;
         }
 


### PR DESCRIPTION
`_get_map_lvalue()` is documented to **"Return NULL when out of memory"**, and
most callers act on that — there are ten sites that raise
`Out of memory when creating mapping entry.` on NULL. Seventeen sites in
`interpret.c` do not check at all, and every one of them either dereferences the
result or offsets it by the column index and stores that as an lvalue.

Assigning into a mapping while memory is short therefore writes through a null
pointer:

```c
mapping m = ([:1]);
for (int i = 0; i < 100000; i++) m[i] = i;
```

With a hard memory limit in force, on master:

```
AddressSanitizer: SEGV on unknown address 0x000000000000
    #0 inl_transfer_svalue
    #1 eval_instruction
```

with this change, same run, same limit:

```
Out of memory when creating mapping entry.
program: t-nodeps.c, object: t-nodeps line 12
```

## The shape of it

Fourteen of the seventeen are the same five lines repeated once per opcode that
can assign to an unprotected mapping entry (`=`, `+=`, `-=`, `*=`, `/=`, `%=`,
`&=`, `|=`, `^=`, `<<=`, `>>=`, `>>>=`, `++`/`--`):

```c
argp = get_map_lvalue(current_unprotected_mapentry.map,
                      &(current_unprotected_mapentry.key))
       + current_unprotected_mapentry.index;
free_svalue(&(current_unprotected_mapentry.key));
```

That repetition is what made it easy to forget the check in the first place, so
rather than adding the same three lines fourteen more times, this adds

```c
static INLINE svalue_t *get_current_mapentry_lvalue (void)
```

which creates the entry, releases the key and raises the error, and returns the
base pointer so the callers keep adding `.index` as before.

**The key has to be released before the error is raised.** Nothing unwinds
`current_unprotected_mapentry`, so raising first would lose that reference — I
checked, there is no cleanup of it on the error path. The two sites that assert
on the fresh entry keep their assert, which is why the helper returns the base
pointer rather than the addressed column.

The remaining three sites take their key from a `protected_mapentry_lvalue`,
which owns it, so there is nothing to release and they get the check inline.

## One more outside interpret.c

`efuns.c`'s struct-to-mapping conversion in `to_type()` passed the unchecked
result of `get_map_lvalue_unchecked()` straight to `free_svalue()`. It now
reports the failure the way the neighbouring conversions in the same file and in
`object.c` do, after releasing the half-built mapping.

## Alternatives considered

- **Add the check inline at all seventeen sites.** Mechanical and reviewable
  line by line, but it grows the file by ~130 lines of the same three lines and
  leaves the next new opcode free to forget it again. The helper makes the
  correct form the short one.
- **Let `get_map_lvalue()` raise the error itself.** Tempting, but it is also
  used where NULL is handled deliberately — `pkg-json.c` and `pkg-pgsql.c` turn
  it into their own diagnostics, and `object.c` uses it during restore, where
  an error would abort the restore of an unrelated object. Changing the
  contract would silently change those.
- **Return a dummy entry** so callers always have something to write to. That
  would turn an out-of-memory condition into silent data loss.

## Tests

There is no automated test, and I would rather say why than add one that does
not test what it claims.

Reaching the code path needs an allocation to fail, and the only way to arrange
that reliably from LPC is the hard memory limit — which is still in force while
the error is being reported. The driver then runs out of memory again inside
`errorf()` (`(strfuns.c:131) Out of memory (56 bytes) for new strbuf`) and gives
up with `Too many simultaneous errors` before a test object could report
anything. That is independent of this change; it happens with and without it.

What the change does is visible in the driver log, as quoted above: the SEGV
inside `inl_transfer_svalue()` becomes a normal error, and the driver proceeds
into the ordinary error handling rather than dying.

The full test suite passes in a normal build and in an ASan/UBSan build.

## Related findings, not part of this PR

Both turned up while reproducing this and are separate concerns:

1. **`get_line_number()` dereferences an unchecked `xalloc()`.** The code says
   so itself:

   ```c
   inc_new = xalloc(sizeof *inc_new);
   /* TODO: What if this fails? */
   inc_new->name = includes->filename;
   ```

   This fires while an error is being *reported*, for any program whose
   line-number info contains include entries, and turns a reportable error into
   a SEGV in `get_line_number()`.

2. **The hard memory limit leaves nothing for reporting the error it causes.**
   `check_max_malloced()` refuses the small allocations that `errorf()` needs,
   and unlike a true out-of-memory condition it never releases the reserved
   areas, so the driver reaches "Too many simultaneous errors". Whether the
   reserves should be usable for that is a design question I did not want to
   answer in a bug fix.