### PR TITLE
comm: add interactive_info(ob, II_WRITE_BUFFER_FILL)

### DIFF
--- a/doc/efun/interactive_info
+++ b/doc/efun/interactive_info
@@ -109,6 +109,27 @@ DESCRIPTION
           The calling object must be privileged by the master object
           via valid_query_snoop().
 
+        <what> == II_WRITE_BUFFER_FILL:
+          Returns the number of bytes that are waiting in the write
+          buffer of <ob>, i.e. that have been given to the driver but
+          could not be handed to the operating system yet.
+
+          This is the value that is checked against the maximum buffer
+          size (configure_interactive(ob, IC_MAX_WRITE_BUFFER_SIZE, ...),
+          queryable with interactive_info(ob, IC_MAX_WRITE_BUFFER_SIZE)):
+          once the fill reaches that maximum, further messages are
+          discarded and H_MSG_DISCARDED is called. Comparing both values
+          allows the mudlib to slow down or drop its own output before
+          that happens - which matters for messages that must not be
+          truncated, as a discarded message is dropped as a whole.
+
+          The value can exceed that maximum by the size of the last
+          write that was still accepted: the limit is checked before a
+          message is queued, not after.
+
+          If compression is active (II_MCCP_STATS), the buffer holds
+          compressed data, so the value counts compressed bytes.
+
 
 HISTORY
         Introduced in LDMud 3.5.0.

--- a/mudlib/sys/interactive_info.h
+++ b/mudlib/sys/interactive_info.h
@@ -27,5 +27,6 @@
 #define II_SNOOP_NEXT                   -30
 #define II_SNOOP_PREV                   -31
 #define II_SNOOP_ALL                    -32
+#define II_WRITE_BUFFER_FILL            -33
 
 #endif /* LPC_INTERACTIVE_INFO_H_ */

--- a/src/comm.c
+++ b/src/comm.c
@@ -9364,6 +9364,14 @@ f_interactive_info (svalue_t *sp)
             put_array(&result, vec);
             break;
         }
+
+    case II_WRITE_BUFFER_FILL:
+        /* The number of bytes waiting in the write buffer. This is the
+         * value that the overflow check in comm_socket_write() compares
+         * against IC_MAX_WRITE_BUFFER_SIZE.
+         */
+        put_number(&result, (p_int)ip->write_size);
+        break;
     }
 
     sp = pop_n_elems(2, sp);

--- a/test/t-write-buffer-fill.c
+++ b/test/t-write-buffer-fill.c
@@ -1,0 +1,100 @@
+/* Check interactive_info(ob, II_WRITE_BUFFER_FILL). */
+
+#include "/inc/base.inc"
+#include "/inc/client.inc"
+
+#include "/sys/interactive_info.h"
+#include "/sys/configuration.h"
+
+void run_server()
+{
+    int max, before, after, drained;
+
+    /* A small socket buffer makes the kernel stop accepting data early,
+     * so that the driver has to queue the rest.
+     */
+    configure_interactive(this_object(), IC_SOCKET_BUFFER_SIZE, 4096);
+
+    max = interactive_info(this_object(), IC_MAX_WRITE_BUFFER_SIZE);
+    before = interactive_info(this_object(), II_WRITE_BUFFER_FILL);
+
+    if (before != 0)
+    {
+        msg("FAILURE: fill is %d on a fresh connection, expected 0.\n", before);
+        shutdown(1);
+        return;
+    }
+
+    /* Write more than any socket send buffer will swallow at once. The
+     * remainder has to be queued, because nothing drains the buffer
+     * until this execution returns to the backend.
+     */
+    for (int i = 0; i < 200; i++)
+        write("x" * 10000);
+
+    after = interactive_info(this_object(), II_WRITE_BUFFER_FILL);
+
+    if (after <= 0)
+    {
+        msg("FAILURE: fill is %d after writing 2000000 bytes.\n", after);
+        shutdown(1);
+        return;
+    }
+
+    msg("fill: %d before, %d after writing 2000000 bytes (maximum %d).\n"
+       , before, after, max);
+
+    /* Non-interactive objects and the default query have no fill. */
+    if (!catch(interactive_info(blueprint(), II_WRITE_BUFFER_FILL); nolog))
+    {
+        msg("FAILURE: no error for a non-interactive object.\n");
+        shutdown(1);
+        return;
+    }
+
+    if (!catch(interactive_info(0, II_WRITE_BUFFER_FILL); nolog))
+    {
+        msg("FAILURE: no error for the default value query.\n");
+        shutdown(1);
+        return;
+    }
+
+    /* And it drops again once the data has been sent. */
+    call_out("check_drained", 2);
+}
+
+void check_drained()
+{
+    int fill = interactive_info(this_object(), II_WRITE_BUFFER_FILL);
+
+    msg("fill after draining: %d.\n", fill);
+
+    if (fill != 0)
+    {
+        msg("FAILURE: buffer did not drain.\n");
+        shutdown(1);
+        return;
+    }
+
+    msg("Success.\n");
+    shutdown(0);
+}
+
+void run_client()
+{
+    /* Nothing to do - the driver reads our side for us. */
+}
+
+void run_test()
+{
+    msg("\nRunning test for II_WRITE_BUFFER_FILL:\n"
+          "---------------------------------------\n");
+
+    connect_self("run_server", "run_client");
+}
+
+string *epilog(int eflag)
+{
+    run_test();
+    return 0;
+}


### PR DESCRIPTION
**This one is a feature, not a bug fix, so it adds public LPC API — please treat
the name and the semantics as a proposal. I am happy to rename it, change what
it returns, or drop it if you would rather not have it.**

## What is missing today

When the write buffer of a connection is full, the driver discards the output,
calls `H_MSG_DISCARDED` and moves on. The mudlib can ask for the maximum with
`interactive_info(ob, IC_MAX_WRITE_BUFFER_SIZE)`, but there is no way to ask how
much of it is in use — so it cannot see the overflow coming, only learn that one
has happened. `II_INPUT_PENDING` covers the input side; this is the missing
counterpart for the output side.

That distinction matters because of *how* the output is dropped.
`add_message_bytes()` hands the message to `comm_socket_write()` in
`MAX_SOCKET_PACKET_SIZE` chunks, and the overflow check rejects individual
chunks. A message that crosses the limit is therefore not dropped as a whole but
**cut in the middle** — for a large GMCP package, in the middle of the JSON, so
the client receives a fragment it cannot parse. There is currently no way for
the mudlib to avoid that other than making the buffer big enough that it never
happens, which is guesswork.

## What this adds

```c
mixed interactive_info(object ob, II_WRITE_BUFFER_FILL)
```

returns `ip->write_size`, the number of bytes waiting in the write buffer. That
is exactly the value the overflow check in `comm_socket_write()` compares
against the maximum, so the mudlib can evaluate the same predicate the driver
does and throttle, summarise or defer its own output before anything is
discarded.

It is purely additive: a new `II_` constant and one `case`. No existing
behaviour changes.

## Two properties worth documenting

Both are in the efun documentation, and the test demonstrates the second:

- If MCCP is active the buffer holds compressed data, so the value counts
  **compressed** bytes.
- The value can **exceed** `IC_MAX_WRITE_BUFFER_SIZE`, because the limit is
  checked before a message is queued and `write_size` is increased after.
  Measured in the test: a fill of 100352 with a maximum of 100000.

## Alternatives considered

- **Expose the discard state (`ip->msg_discarded`) as well.** Deliberately not
  in this PR: `H_MSG_DISCARDED` already tells the mudlib that something was
  dropped, so the fill level is the part that is actually missing. Easy to add
  later if you want it.
- **Report the fill as a percentage of the maximum**, which would avoid the
  overshoot above. It loses information (the maximum can be "infinite", -1), and
  a byte count composes better with `IC_MAX_WRITE_BUFFER_SIZE`, which is also a
  byte count.
- **A configuration value (`IC_...`) instead of an information value
  (`II_...`).** The fill is not configurable, so `II_` is the right half of the
  namespace; `IC_MAX_WRITE_BUFFER_SIZE` stays where it is.
- **The bigger version of this**: a driver hook that is asked *before* a message
  is discarded and can answer "keep buffering". That is a much larger change and
  a behaviour change; with the fill exposed, a mudlib can implement backpressure
  on its own, so this seemed the right first step. I would be glad to work on
  the hook if you are interested.

## Tests

`test/t-write-buffer-fill.c` connects the driver to itself with the existing
`connect_self()` helper, shrinks the socket buffer with
`configure_interactive(IC_SOCKET_BUFFER_SIZE, 4096)` so that the kernel stops
accepting data early, and then checks that

- the fill is 0 on a fresh connection,
- it grows once data cannot be handed to the operating system,
- it drops back to 0 after the data has been sent,
- and that querying a non-interactive object or the default value (`ob == 0`)
  raises an error, like the other `II_` values.

Without the new `case` in `f_interactive_info()` the test fails on the first
query. The full test suite passes in a normal build and in an ASan/UBSan build.

## Unrelated finding

While writing the test I noticed that an error which escapes `logon()` leaves
the interactive object with one reference too many —
`Bad ref count in object <ob>: listed 47 - counted 46`, repeated at every
`--check-refcounts` pass for as long as the object lives. It reproduces on
unmodified master with nothing but

```c
void run_server() { raise_error("boom\n"); }
```

in the `connect_self()` harness, so it has nothing to do with this change. I
only characterised it far enough to be sure of that, and can look into it
separately if it is not already known.