### PR TITLE
backend: release the stale apply result in clear_state()

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -286,6 +286,15 @@ clear_state (void)
     current_interactive = NULL;
     previous_ob = const0;
     current_prog = NULL;
+
+    /* An error can interrupt an apply before it stored its result,
+     * leaving the result of the previous apply in <apply_return_value>.
+     * Unlike the borrowed references above this one is owned and must
+     * be released, or it will keep its value alive indefinitely.
+     */
+    free_svalue(&apply_return_value);
+    put_number(&apply_return_value, 0);
+
     reset_machine(MY_FALSE);   /* Pop down the stack. */
     num_warning = 0;
 } /* clear_state() */

--- a/test/t-logon-error-refcount.c
+++ b/test/t-logon-error-refcount.c
@@ -1,0 +1,68 @@
+#pragma save_types, rtt_checks
+#include "/inc/base.inc"
+#include "/inc/client.inc"
+
+#include "/sys/configuration.h"
+
+/* An uncaught error thrown from logon() must not leave a stale
+ * reference to the player object behind.
+ *
+ * The object returned by master::connect() is kept in the driver's
+ * static apply result until the next apply completes. When logon()
+ * throws, the error recovery returns straight to the backend without
+ * storing a new result, and clear_state() has to release the old one.
+ * If it does not, the --check-refcounts pass reports the object with
+ * one reference too many ("Bad ref count") on every backend cycle.
+ */
+
+int checks;
+
+void run_server()
+{
+    raise_error("boom\n");
+}
+
+void run_client()
+{
+    /* Nothing to do. */
+}
+
+void check_log()
+{
+    string log = read_file(driver_info(DC_DEBUG_FILE));
+
+    if (stringp(log) && strstr(log, "Bad ref count") >= 0)
+    {
+        msg("FAILURE: The error from logon() left a stale reference.\n");
+        shutdown(1);
+        return;
+    }
+
+    /* Give the refcount check some backend cycles to run. */
+    if (++checks > 3)
+    {
+        msg("Success.\n");
+        shutdown(0);
+        return;
+    }
+
+    call_out("check_log", __ALARM_TIME__);
+}
+
+void run_test()
+{
+    msg("\nRunning test for an uncaught error in logon():\n"
+          "----------------------------------------------\n");
+
+    connect_self("run_server", "run_client");
+    call_out("check_log", 2 * __ALARM_TIME__);
+
+    /* Safety net in case the check never finishes. */
+    call_out(#'shutdown, 20 * __ALARM_TIME__, 1);
+}
+
+string *epilog(int eflag)
+{
+    run_test();
+    return 0;
+}


### PR DESCRIPTION
This is the follow-up to the finding reported in #145: an error thrown from
`logon()` leaves the interactive object with one reference too many, reported
as `Bad ref count in object <ob>: listed 47 - counted 46` on every
`--check-refcounts` pass.

## Cause

The result of every apply lives in the static `apply_return_value` until the
next apply completes: `pop_apply_value()` frees the old value right before
storing the new one. When an uncaught runtime error aborts an apply, the
`longjmp` returns straight to the backend and `pop_apply_value()` is skipped —
so `apply_return_value` still owns the result of the *previous* apply.
`clear_state()`, whose job is exactly to "clear the global variables of the
virtual machine [...] after errors, which return directly to the backend,
thus skipping the clean-up code in the VM itself", resets the borrowed
references (`current_object`, `previous_ob`, `command_giver`, ...) but not
this owned one.

For an incoming connection the sequence is: `master::connect()` returns the
player object — that object is now in `apply_return_value` — and then
`new_player()` calls `logon()` in it. If `logon()` throws, the player object
stays referenced by `apply_return_value` until some later apply happens to
complete and overwrite it. In a quiet driver that can be arbitrarily long.

Two consequences:

* The object (and everything it references) is kept alive although nothing
  reachable refers to it any more.
* `check_a_lot_ref_counts()` does not scan `apply_return_value`, so it cannot
  see the reference it is counting against and reports a bad ref count once
  per backend cycle, which sends whoever runs with `--check-refcounts` hunting
  for a corruption that isn't one.

The behaviour is old — the missing release predates the initial import from
PRCS in 1999.

## Fix

`clear_state()` releases `apply_return_value` along with the other VM
globals. After an error this is the designated cleanup; in the regular
backend cycle (`clear_state()` also runs via `cleanup_stuff()`) the result of
the last apply is no longer reachable by any C caller, so releasing it there
is safe: every `sapply()` caller consumes the returned pointer before giving
up control, and the documented lifetime ("valid until the next sapply") is
unchanged.

## Alternatives considered

* **Free the value in the error handling in `simulate.c`** when unwinding to
  `ERROR_RECOVERY_BACKEND`. Works for this case, but `clear_state()` is the
  function whose documented purpose is to redo the cleanup the VM skipped,
  and it is also reached from the heart-beat and `process_objects()` recovery
  paths. Splitting the knowledge about `apply_return_value` across the error
  machinery seemed worse.
* **Make `check_a_lot_ref_counts()` count `apply_return_value`.** That only
  silences the report; the object would still be kept alive indefinitely.
  With the fix the variable is empty whenever the check runs, so the checker
  needs no change.
* **Free the old value at the start of the next apply** instead of at its
  end. Keeps the documented lifetime too, but adds work to the hot apply path
  and does not help when no further apply happens at all.
* **Call `free_interpreter_temporaries()` from `clear_state()`.** Most
  thorough — it would also cover `struct_member_temporary` and the
  unprotected map-entry keys, which have the same skipped-cleanup lifecycle —
  but `clear_state()` runs once per object in the `process_objects()` loop
  and `free_interpreter_temporaries()` scans the whole `TRACE_CODE` ring
  buffer on every call, which is too expensive there.

## Related findings not part of this PR

* `struct_member_temporary` and `current_unprotected_mapentry.key` /
  `current_unprotected_map_range.key` follow the same pattern: owned VM
  globals that an error can leave populated until their next use. They are
  short-lived in practice and I have no reproduction that makes them
  observable, so I left them alone rather than change behaviour I cannot
  test. If you would like them released in `clear_state()` as well, I am
  happy to add that here.
* The client side of `net_connect()` already handles a throwing `logon()`
  explicitly (`ocLoggingOn` cleanup in `check_for_out_connections()`), but it
  shares the generic mechanism above — any uncaught error leaves the previous
  apply's result stale, `logon()` is merely the case where that result is
  visibly an object.

## Test

`test/t-logon-error-refcount.c` connects to itself, raises an error from
`logon()` on the server side and then watches the debug log (found via
`driver_info(DC_DEBUG_FILE)`) for `Bad ref count` messages from the
`--check-refcounts` pass that `test/run.sh` enables.

* Without the fix the message appears within two backend cycles and the test
  fails; with the fix it stays clean over the whole observation window
  (five consecutive runs).
* The full test suite passes in a normal build and in an ASan/UBSan build
  (`-fsanitize=address,undefined`); the sanitizer output shows only the known
  unaligned-access noise from the packed bytecode stream and MurmurHash, none
  of it in `backend.c`.