### PR TITLE
interpret: handle allocation failure in get_line_number()

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -22243,7 +22243,35 @@ get_line_number (bytecode_p p, program_t *progp, string_t **namep, string_t **fn
 
                         i++;
                         inc_new = xalloc(sizeof *inc_new);
-                        /* TODO: What if this fails? */
+                        if (!inc_new)
+                        {
+                            /* Out of memory: we cannot follow the include
+                             * structure any further, so report the position
+                             * as unknown, like the other failure modes above.
+                             */
+                            while (inctop)
+                            {
+                                struct incinfo *inc_old;
+
+                                inc_old = inctop;
+                                inctop = inc_old->super;
+                                xfree(inc_old);
+                            }
+
+                            if (used_system_mem)
+                            {
+                                total_prog_block_size -= progp->line_numbers->size;
+                                total_bytes_unswapped -= progp->line_numbers->size;
+                                xfree(progp->line_numbers);
+                                progp->line_numbers = NULL;
+                                reallocate_reserved_areas();
+                            }
+
+                            *namep = ref_mstring(STR_UNDEFINED);
+                            if (fnamep)
+                                *fnamep = NULL;
+                            return 0;
+                        }
                         inc_new->name = includes->filename;
                         includes++;
                         inc_new->super = inctop;

--- a/test/t-line-number-oom.c
+++ b/test/t-line-number-oom.c
@@ -1,0 +1,121 @@
+#pragma save_types, rtt_checks
+#include "/inc/base.inc"
+#include "/inc/msg.inc"
+
+#include "/sys/functionlist.h"
+#include "/sys/configuration.h"
+
+/* get_line_number() allocates one incinfo frame per include level
+ * while decoding the position of code that lives in an included file.
+ * When that allocation fails, it must report the position as unknown
+ * instead of dereferencing the NULL pointer.
+ *
+ * We force the failure with the runtime hard memory limit: probe for
+ * the smallest settable limit (the driver rejects limits at or below
+ * the current allocation), activate it, and then ask for the line
+ * number of a function nested DEPTH includes deep. The decoder has to
+ * allocate DEPTH frames, several kilobytes in sum, which is well above
+ * whatever headroom the probe left - so one of the allocations fails.
+ *
+ * A failed configure_driver() leaves the limit unchanged, so every
+ * catch() below runs with an unlimited allocator and can report its
+ * error safely.
+ */
+
+#define DEPTH 12
+
+void cleanup_files()
+{
+    rm("/tmp-lnoom-ob.c");
+    for (int i = 0; i < DEPTH; i++)
+        rm(sprintf("/tmp-lnoom-%d.inc", i));
+}
+
+void run_test()
+{
+    int line_normal, line_oom, i, lo, hi;
+    object ob;
+    string fname, incfile;
+    mixed *restore = ({ 0, 0 });   /* preallocated: back to unlimited */
+    mixed *setarr  = ({ 0, 0 });   /* preallocated probe/set array */
+
+    msg("\nRunning test for get_line_number() under memory pressure:\n"
+          "---------------------------------------------------------\n");
+
+    /* Build the nested includes at runtime. */
+    for (i = 0; i < DEPTH; i++)
+    {
+        string body = sprintf("int fun_%d() { return %d; }\n", i, i);
+        if (i < DEPTH - 1)
+            body = sprintf("%s#include \"tmp-lnoom-%d.inc\"\n", body, i + 1);
+        write_file(sprintf("/tmp-lnoom-%d.inc", i), body, 1);
+    }
+    write_file("/tmp-lnoom-ob.c", "#include \"tmp-lnoom-0.inc\"\n", 1);
+    ob = load_object("/tmp-lnoom-ob");
+
+    fname = sprintf("fun_%d", DEPTH - 1);
+    line_normal = function_exists(fname, ob, FEXISTS_LINENO);
+    incfile = function_exists(fname, ob, FEXISTS_FILENAME);
+    msg("normal: %s at line %d in %s\n", fname, line_normal, incfile);
+
+    if (line_normal != 1
+     || incfile != sprintf("/tmp-lnoom-ob.c (/tmp-lnoom-%d.inc)", DEPTH - 1))
+    {
+        msg("FAILURE: unexpected line info for the nested function.\n");
+        cleanup_files();
+        shutdown(1);
+        return;
+    }
+
+    /* Find the smallest settable hard limit. */
+    lo = 1; hi = 0x40000000;
+    while (hi - lo > 64)
+    {
+        int mid = lo + (hi - lo) / 2;
+
+        setarr[1] = mid;
+        if (catch(configure_driver(DC_MEMORY_LIMIT, setarr); nolog))
+            lo = mid;
+        else
+        {
+            configure_driver(DC_MEMORY_LIMIT, restore);
+            hi = mid;
+        }
+    }
+
+    /* Activate it; widen if the usage drifted upwards meanwhile. */
+    for (i = 0; ; i++)
+    {
+        setarr[1] = hi + i * 64;
+        if (!catch(configure_driver(DC_MEMORY_LIMIT, setarr); nolog))
+            break;
+    }
+
+    /* From here to the restore: no allocations except the ones
+     * inside get_line_number().
+     */
+    line_oom = function_exists(fname, ob, FEXISTS_LINENO);
+
+    configure_driver(DC_MEMORY_LIMIT, restore);
+
+    msg("under memory pressure: line %d\n", line_oom);
+
+    cleanup_files();
+
+    if (line_oom != 0)
+    {
+        msg("FAILURE: expected the position to be unknown (0), got %d.\n"
+           , line_oom);
+        shutdown(1);
+        return;
+    }
+
+    msg("Success.\n");
+    shutdown(0);
+}
+
+string *epilog(int eflag)
+{
+    run_test();
+    return 0;
+}


### PR DESCRIPTION
This is the follow-up announced in #144: `get_line_number()` dereferences an
unchecked `xalloc()`, and the code has known it for a while:

```c
inc_new = xalloc(sizeof *inc_new);
/* TODO: What if this fails? */
inc_new->name = includes->filename;
```

## Why this matters

The decoder allocates one `incinfo` frame per include level while looking up
the position of code that lives in an included file. `get_line_number()` runs
exactly in the situations where memory is short: while an error is being
reported (`dump_trace()`, `get_line_number_if_any()`), from the malloc trace
dump in `xalloc.c` itself, and for every `function_exists(...,
FEXISTS_LINENO)` query. When the allocation fails, the driver segfaults in
the middle of reporting a problem, instead of reporting it with an unknown
position.

## Fix

Check the allocation. On failure, release the frames allocated so far,
return the swap memory if the line-number information was pulled in with
SYSTEM privilege (the same bookkeeping the function end does), and report
the position as unknown — line 0, file `<Undefined>` — exactly like the
existing failure modes at the top of the function (no line-number info,
illegal offset).

## Alternatives considered

* **`xallocate()`, i.e. throw on failure.** `get_line_number()` runs during
  error reporting and from the allocator's own trace dump; throwing there
  turns a reportable error into a secondary error in mid-unwind (or worse,
  in `xalloc.c`'s dump path). Rejected.
* **Pull rank with `malloc_privilege = MALLOC_SYSTEM` and retry**, like the
  swap-load a few lines above does. Besides spending the emergency reserve
  on nicer line numbers, this is actively dangerous under the hard memory
  limit: `check_max_malloced()` reacts to a SYSTEM-privileged allocation
  over the limit with `fatal()`. An unknown position is strictly better
  than an aborted driver. Rejected.
* **Continue decoding without the frame** (count the skipped pushes so
  `LI_INCLUDE_END` stays balanced). Keeps decoding, but the positions after
  the failed push would be attributed to the wrong file with a plausible-
  looking line number. Wrong-but-plausible is worse than unknown. Rejected.
* **A fixed-size frame array with heap fallback.** The include depth is
  unbounded, so the fallback — and with it this same failure path — stays;
  extra complexity without removing the case. Rejected.

## Test

The interesting part of `test/t-line-number-oom.c` is that it forces the
allocation failure deterministically from plain LPC, with no special build:

1. It writes and loads an object whose innermost function sits below
   twelve nested includes, and verifies the normal lookup
   (`fun_11 at line 1 in /tmp-lnoom-ob.c (/tmp-lnoom-11.inc)`).
2. It probes for the smallest settable hard memory limit by binary search
   with `configure_driver(DC_MEMORY_LIMIT, ...)`. The driver rejects limits
   at or below the current allocation, and a rejected attempt leaves the
   limit unchanged — so every `catch()` in the probe runs with an unlimited
   allocator and can report its error safely. A successful attempt is
   immediately reverted.
3. It activates the found limit and asks for the line number of the nested
   function. The decoder has to allocate twelve frames — several hundred
   bytes in sum, more than the probe's ≤64-byte granularity leaves as
   headroom — so one of the allocations fails. No other allocation happens
   between activating the limit and restoring it: `FEXISTS_LINENO` returns
   a plain number, and both configure_driver() arrays are preallocated.

Without the fix the driver segfaults at that point (`HARD_MALLOC_LIMIT
reached.` followed by `Segmentation fault`; gdb places the fault in the
`LI_INCLUDE` branch of `get_line_number()`, reached via
`v_function_exists()`); with the fix the query returns 0. Ten consecutive runs pass. The full test suite passes in a
normal build and in an ASan/UBSan build; the sanitizer output shows only
the known unaligned-access noise from the packed bytecode stream, nothing
in the changed code.

## Related findings not part of this PR

* The `Illegal offset` early return a few lines above keeps the
  line-number block resident even when it was loaded with SYSTEM
  privilege, i.e. it skips the release/`reallocate_reserved_areas()`
  bookkeeping the function end performs. Harmless (the block stays
  accounted), so I left it alone rather than widen the diff.
* `LI_INCLUDE_END` pops `inctop` without a NULL check. With
  driver-generated line-number info the stream is always balanced, so I
  did not touch it.
* The second follow-up announced in #144 — the hard memory limit starving
  `errorf()` itself so the driver reaches "Too many simultaneous errors" —
  is still open; it is a design question rather than a bug fix.