### PR TITLE
comm: add MXP/Pueblo protocol support

### DIFF
--- a/doc/efun/configure_interactive
+++ b/doc/efun/configure_interactive
@@ -95,6 +95,27 @@ DESCRIPTION
           part of the user input. Also INPUT_NOECHO won't be effective
           as the driver won't send any telnet negotiations itself.
 
+        <what> == IC_MXP
+          Configures driver-assisted MXP/Pueblo detection for <ob>.
+          <data> is a bitmask of request bits from <configuration.h>.
+
+          MXP_TELOPT asks the driver to negotiate the MXP telnet option
+          by sending IAC DO TELOPT_MXP when the telnet machine is
+          enabled. If the client answers WILL TELOPT_MXP, the driver
+          sets MXP_TELOPT_ACTIVE. If H_NOECHO lets the mudlib handle
+          telnet negotiation, this request bit is only stored and the
+          driver does not negotiate TELOPT_MXP.
+
+          MXP_PUEBLO asks the driver to recognize an initial Pueblo
+          client response line whose first token is PUEBLOCLIENT. The
+          line is consumed, MXP_PUEBLO_ACTIVE is set, and the driver
+          sends the Pueblo HTML-mode switch sequence.
+
+          Only MXP_TELOPT and MXP_PUEBLO may be configured. The active
+          bits MXP_TELOPT_ACTIVE and MXP_PUEBLO_ACTIVE are reported by
+          interactive_info() and cannot be set directly. There is no
+          default IC_MXP setting for future interactives.
+
         <what> == IC_MCCP
           Starts oder ends MCCP compression of the driver -> client traffic.
           <data> must be the MCCP version (either TELOPT_COMPRESS or
@@ -147,6 +168,7 @@ DESCRIPTION
 HISTORY
         Introduced in LDMud 3.3.719.
         IC_ENCODING introduced in LDMud 3.6.0.
+        IC_MXP introduced in LDMud 3.6.8.
 
 
 SEE ALSO

--- a/doc/efun/configure_interactive
+++ b/doc/efun/configure_interactive
@@ -100,11 +100,17 @@ DESCRIPTION
           <data> is a bitmask of request bits from <configuration.h>.
 
           MXP_TELOPT asks the driver to negotiate the MXP telnet option
-          by sending IAC DO TELOPT_MXP when the telnet machine is
-          enabled. If the client answers WILL TELOPT_MXP, the driver
+          by sending IAC WILL TELOPT_MXP when the telnet machine is
+          enabled. If the client answers DO TELOPT_MXP, the driver
           sets MXP_TELOPT_ACTIVE. If H_NOECHO lets the mudlib handle
           telnet negotiation, this request bit is only stored and the
-          driver does not negotiate TELOPT_MXP.
+          driver does not negotiate TELOPT_MXP. Clearing MXP_TELOPT
+          sends IAC WONT TELOPT_MXP if the driver previously offered
+          the option.
+
+          MXP_TELOPT_ACTIVE reports only that the client accepted the
+          option. The mudlib remains responsible for sending MXP mode
+          escapes and markup.
 
           MXP_PUEBLO asks the driver to recognize an initial Pueblo
           client response line whose first token is PUEBLOCLIENT. The

--- a/doc/efun/interactive_info
+++ b/doc/efun/interactive_info
@@ -54,9 +54,9 @@ DESCRIPTION
           bits MXP_TELOPT and MXP_PUEBLO indicate which driver-assisted
           protocol detection was configured with configure_interactive().
           The active bits MXP_TELOPT_ACTIVE and MXP_PUEBLO_ACTIVE indicate
-          that the client acknowledged TELOPT_MXP or sent the Pueblo
-          client response line. There is no default IC_MXP query for
-          future interactives.
+          that the client accepted the server's WILL TELOPT_MXP offer
+          with DO TELOPT_MXP or sent the Pueblo client response line.
+          There is no default IC_MXP query for future interactives.
 
         <what> == II_MCCP_STATS:
           Statistics about the current compression of <ob> given

--- a/doc/efun/interactive_info
+++ b/doc/efun/interactive_info
@@ -49,6 +49,15 @@ DESCRIPTION
 
         Telnet Related Information:
 
+        <what> == IC_MXP:
+          Returns the MXP/Pueblo state of <ob> as a bitmask. The request
+          bits MXP_TELOPT and MXP_PUEBLO indicate which driver-assisted
+          protocol detection was configured with configure_interactive().
+          The active bits MXP_TELOPT_ACTIVE and MXP_PUEBLO_ACTIVE indicate
+          that the client acknowledged TELOPT_MXP or sent the Pueblo
+          client response line. There is no default IC_MXP query for
+          future interactives.
+
         <what> == II_MCCP_STATS:
           Statistics about the current compression of <ob> given
           as an array ({ uncompressed bytes, compressed bytes }).
@@ -112,6 +121,7 @@ DESCRIPTION
 
 HISTORY
         Introduced in LDMud 3.5.0.
+        IC_MXP introduced in LDMud 3.6.8.
 
 SEE ALSO
         configure_interactive(E), object_info(E), driver_info(E)

--- a/mudlib/sys/configuration.h
+++ b/mudlib/sys/configuration.h
@@ -19,6 +19,14 @@
 #define IC_MAX_COMMANDS                 10
 #define IC_MODIFY_COMMAND               11
 #define IC_ENCODING                     12
+#define IC_MXP                          13
+
+/* Bit values for IC_MXP.
+ */
+#define MXP_TELOPT                      0x01
+#define MXP_PUEBLO                      0x02
+#define MXP_TELOPT_ACTIVE               0x04
+#define MXP_PUEBLO_ACTIVE               0x08
 
 /* Possible options for configure_object().
  */

--- a/src/access_check.c
+++ b/src/access_check.c
@@ -346,7 +346,8 @@ read_access_file (void)
 
             for (;;) {
                 c = 'm';
-                fscanf(infp, "%c %1[=]", &c, c2);
+                if (fscanf(infp, "%c %1[=]", &c, c2) < 1)
+                    c = 'm';
                 switch(c)
                 {
                 case 'w':
@@ -366,7 +367,9 @@ read_access_file (void)
                             break;
                         if (*c2 == '-') {
                             k = 24;
-                            fscanf(infp, "%d %1[,:] ", &k, c2);
+                            if (fscanf(infp, "%d %1[,:] ", &k, c2) < 1)
+                                break;
+
                             if (j <= k) {
                                 mask |= (2 << k) - (1 << j);
                             } else {
@@ -393,7 +396,8 @@ read_access_file (void)
 
         /* The rest of the line is the message to print.
          */
-        fgets(message, (int)sizeof(message)-1, infp);
+        if (fgets(message, (int)sizeof(message)-1, infp) == NULL)
+            message[0] = '\0';
         message[sizeof(message) - 1] = '\0';
 
         /* Check if this rule creates a new class. If yes, allocate

--- a/src/backend.c
+++ b/src/backend.c
@@ -836,7 +836,7 @@ backend (void)
                              , slow_shut_down_to_do
                              , (long)(time_now - time_last_gc)
                              );
-                  write(1, buf, strlen(buf));
+                  writes(1, buf);
                   command_giver = NULL;
                   clear_current_object();
                   /* if the GC was not requested by an efun call, low_memory()
@@ -855,7 +855,7 @@ backend (void)
                              , gc_request == gcEfun ? "efun" : "allocator"
                              , slow_shut_down_to_do
                              , (long)(time_now - time_last_gc));
-                  write(1, buf, strlen(buf));
+                  writes(1, buf);
                   reallocate_reserved_areas();
                 }
 
@@ -874,7 +874,7 @@ backend (void)
                         time_last_slow_shut = time_now;
                         malloc_privilege = MALLOC_MASTER;
                         sprintf(shut_msg, "%s slow_shut_down(%d)\n", time_stamp(), minutes);
-                        write(1, shut_msg, strlen(shut_msg));
+                        writes(1, shut_msg);
 
                         previous_ob = const0;
                         command_giver = NULL;
@@ -888,7 +888,7 @@ backend (void)
                         sprintf(buf, "%s Last slow_shut_down() still pending.\n"
                                    , time_stamp()
                                );
-                        write(1, buf, strlen(buf));
+                        writes(1, buf);
                     }
                 }
                 malloc_privilege = MALLOC_USER;

--- a/src/comm.c
+++ b/src/comm.c
@@ -443,6 +443,13 @@ static void (*telopts_do  [NTELOPTS])(int);
 static void (*telopts_dont[NTELOPTS])(int);
 static void (*telopts_will[NTELOPTS])(int);
 static void (*telopts_wont[NTELOPTS])(int);
+static Bool telopts_are_driver_owned = MY_TRUE;
+
+#define MXP_REQUEST_MASK (MXP_TELOPT|MXP_PUEBLO)
+#define MXP_ACTIVE_MASK  (MXP_TELOPT_ACTIVE|MXP_PUEBLO_ACTIVE)
+#define MXP_PUBLIC_MASK  (MXP_REQUEST_MASK|MXP_ACTIVE_MASK)
+#define MXP_TELOPT_SENT    0x10
+#define MXP_PUEBLO_CHECKED 0x20
 
   /* Tables with the telnet statemachine handlers.
    */
@@ -740,6 +747,7 @@ comm_fatal (interactive_t *ip, char *fmt, ...)
       dump_bytes(&(ip->addr), sizeof(ip->addr), 21);
     fprintf(stderr, "  .closing:           %02hhx\n", (unsigned char)ip->closing);
     fprintf(stderr, "  .tn_enabled:        %02hhx\n", (unsigned char)ip->tn_enabled);
+    fprintf(stderr, "  .mxp:               %02hhx\n", (unsigned char)ip->mxp);
     fprintf(stderr, "  .do_close:          %02hhx", (unsigned char)ip->do_close);
       if (ip->do_close & (FLAG_DO_CLOSE|FLAG_PROTO_ERQ)) fprintf(stderr, " (");
       if (ip->do_close & FLAG_DO_CLOSE) fprintf(stderr, "DO_CLOSE");
@@ -3673,6 +3681,7 @@ new_player ( object_t *ob, SOCKET_T new_socket
     new_interactive->modify_command = NULL;
     new_interactive->closing = MY_FALSE;
     new_interactive->tn_enabled = MY_TRUE;
+    new_interactive->mxp = 0;
     new_interactive->do_close = 0;
     new_interactive->noecho = 0;
     new_interactive->supress_go_ahead = MY_FALSE;
@@ -4664,6 +4673,97 @@ send_do (int option)
 
 /*-------------------------------------------------------------------------*/
 static void
+send_bytes_to_interactive (interactive_t *ip, const char *bytes, size_t len)
+
+/* Send <bytes> directly to <ip>, preserving the previous command_giver.
+ */
+
+{
+    object_t *save_command_giver = command_giver;
+
+    if (ip == NULL || ip->ob == NULL || (ip->ob->flags & O_DESTRUCTED))
+        return;
+
+    command_giver = ip->ob;
+    add_message_bytes(bytes, len);
+    add_message_flush();
+    command_giver = save_command_giver;
+} /* send_bytes_to_interactive() */
+
+/*-------------------------------------------------------------------------*/
+static void
+send_telnet_option_to_interactive (interactive_t *ip, char action, char option)
+
+/* Send IAC <action> <option> directly to <ip>.
+ */
+
+{
+    char msg[3];
+
+    msg[0] = (char) IAC;
+    msg[1] = action;
+    msg[2] = option;
+
+    send_bytes_to_interactive(ip, msg, sizeof(msg));
+} /* send_telnet_option_to_interactive() */
+
+/*-------------------------------------------------------------------------*/
+static void
+request_mxp_telopt (interactive_t *ip)
+
+/* Request MXP telnet support from <ip>, if configured and possible.
+ */
+
+{
+    if (ip->tn_enabled
+     && telopts_are_driver_owned
+     && (ip->mxp & MXP_TELOPT)
+     && !(ip->mxp & (MXP_TELOPT_SENT|MXP_TELOPT_ACTIVE)))
+    {
+        send_telnet_option_to_interactive(ip, (char)DO, (char)TELOPT_MXP);
+        ip->mxp |= MXP_TELOPT_SENT;
+    }
+} /* request_mxp_telopt() */
+
+/*-------------------------------------------------------------------------*/
+static bool
+is_pueblo_client_command (const char *str, size_t len)
+
+/* Return true if <str> is the Pueblo client response line.
+ */
+
+{
+    static const char pueblo[] = "PUEBLOCLIENT";
+    size_t pueblo_len = sizeof(pueblo) - 1;
+
+    if (len < pueblo_len)
+        return false;
+
+    if (memcmp(str, pueblo, pueblo_len) != 0)
+        return false;
+
+    return len == pueblo_len
+        || str[pueblo_len] == ' '
+        || str[pueblo_len] == '\t'
+        || str[pueblo_len] == '\v'
+        || str[pueblo_len] == '\f';
+} /* is_pueblo_client_command() */
+
+/*-------------------------------------------------------------------------*/
+static void
+send_pueblo_html_mode (interactive_t *ip)
+
+/* Send the Pueblo sequence that switches the client to HTML mode.
+ */
+
+{
+    static const char mode[] = "</xch_mudtext><xch_mode=html>";
+
+    send_bytes_to_interactive(ip, mode, sizeof(mode) - 1);
+} /* send_pueblo_html_mode() */
+
+/*-------------------------------------------------------------------------*/
+static void
 reply_to_do_echo (int option)
 
 /* Send IAC WONT <option> if we don't want noecho mode.
@@ -4857,6 +4957,48 @@ mccp_telnet_neg (int option)
 } /* mccp_telnet_neg() */
 
 /*-------------------------------------------------------------------------*/
+static void
+mxp_telnet_neg (int option)
+
+/* Handle MXP telnet option negotiation.
+ */
+
+{
+    interactive_t *ip = O_GET_INTERACTIVE(command_giver);
+
+    switch (ip->tn_state)
+    {
+    case TS_WILL:
+        if (ip->mxp & MXP_TELOPT)
+        {
+            if (!(ip->mxp & MXP_TELOPT_SENT))
+            {
+                send_do(option);
+                ip->mxp |= MXP_TELOPT_SENT;
+            }
+            ip->mxp |= MXP_TELOPT_ACTIVE;
+        }
+        else
+        {
+            send_dont(option);
+        }
+        break;
+
+    case TS_WONT:
+        ip->mxp &= ~(MXP_TELOPT_SENT|MXP_TELOPT_ACTIVE);
+        break;
+
+    case TS_DO:
+        send_wont(option);
+        break;
+
+    case TS_DONT:
+        ip->mxp &= ~(MXP_TELOPT_SENT|MXP_TELOPT_ACTIVE);
+        break;
+    }
+} /* mxp_telnet_neg() */
+
+/*-------------------------------------------------------------------------*/
 static svalue_t *
 h_telnet_neg (int n)
 
@@ -4952,6 +5094,8 @@ init_telopts (void)
 {
     int i;
 
+    telopts_are_driver_owned = MY_TRUE;
+
     /* Pass all telnet options that we're not
      * able to handle to the mudlib.
      */
@@ -4993,6 +5137,11 @@ init_telopts (void)
     telopts_dont[TELOPT_COMPRESS2] = mccp_telnet_neg;
     telopts_will[TELOPT_COMPRESS2] = mccp_telnet_neg;
     telopts_wont[TELOPT_COMPRESS2] = mccp_telnet_neg;
+
+    telopts_do[TELOPT_MXP] = mxp_telnet_neg;
+    telopts_dont[TELOPT_MXP] = mxp_telnet_neg;
+    telopts_will[TELOPT_MXP] = mxp_telnet_neg;
+    telopts_wont[TELOPT_MXP] = mxp_telnet_neg;
 } /* init_telopts() */
 
 /*-------------------------------------------------------------------------*/
@@ -5008,6 +5157,7 @@ mudlib_telopts (void)
     int i;
 
     DT(("All telnet options set to the mudlib.\n"));
+    telopts_are_driver_owned = MY_FALSE;
     for (i = NTELOPTS; --i >= 0; ) {
         telopts_do[i] = telopts_dont[i] =
           telopts_will[i] = telopts_wont[i] = reply_h_telnet_neg;
@@ -5146,6 +5296,7 @@ telnet_neg (interactive_t *ip)
                 char *command_to = command_from;                                /* Where to put the processed chars. */
                 char *command_end = ip->command + ip->command_unprocessed_end;  /* End of the unprocessed chars. */
                 bool ready = false;                                             /* Whether we have a command to return. */
+                bool line_ready = false;                                        /* Whether a line mode command is ready. */
 
                 if (ip->command_start > 1)
                 {
@@ -5269,6 +5420,8 @@ telnet_neg (interactive_t *ip)
 
                             set_tn_state(ip, TS_READY);
 
+                            if (!charmode)
+                                line_ready = true;
                             ready = true;
                             break;
                         }
@@ -5279,7 +5432,36 @@ telnet_neg (interactive_t *ip)
                     }
 
                     if (ready)
+                    {
+                        if (line_ready
+                         && !(ip->mxp & MXP_PUEBLO_CHECKED))
+                        {
+                            ip->mxp |= MXP_PUEBLO_CHECKED;
+
+                            if ((ip->mxp & MXP_PUEBLO)
+                             && !(ip->mxp & MXP_PUEBLO_ACTIVE)
+                             && is_pueblo_client_command(ip->command + ip->command_start,
+                                    command_to - (ip->command + ip->command_start)))
+                            {
+                                size_t remaining = command_end - command_from;
+                                char *line_start = ip->command + ip->command_start;
+
+                                ip->mxp |= MXP_PUEBLO_ACTIVE;
+                                send_pueblo_html_mode(ip);
+
+                                memmove(line_start, command_from, remaining);
+                                command_from = line_start;
+                                command_to = line_start;
+                                command_end = line_start + remaining;
+                                ready = false;
+                                line_ready = false;
+                                set_tn_state(ip, TS_DATA);
+                                continue;
+                            }
+                        }
+
                         break;
+                    }
 
                     command_from++;
 
@@ -8867,6 +9049,41 @@ f_configure_interactive (svalue_t *sp)
             efun_exp_arg_error(3, TF_NUMBER, sp, sp);
 
         ip->tn_enabled = (sp->u.number != 0);
+        if (ip->tn_enabled)
+            request_mxp_telopt(ip);
+        else
+            ip->mxp &= ~(MXP_TELOPT_SENT|MXP_TELOPT_ACTIVE);
+        break;
+
+    case IC_MXP:
+        if (!ip)
+            errorf("Default value for IC_MXP is not supported.\n");
+
+        if (sp->type != T_NUMBER)
+            efun_exp_arg_error(3, TF_NUMBER, sp, sp);
+
+        if (sp->u.number & ~(p_int)MXP_REQUEST_MASK)
+            errorf("Illegal value to arg 3 of configure_interactive with IC_MXP: %ld.\n",
+                (long)sp->u.number);
+
+        {
+            char old_mxp = ip->mxp;
+            char new_mxp = (char)((sp->u.number & MXP_REQUEST_MASK)
+                              | (old_mxp & MXP_PUEBLO_CHECKED));
+
+            if (new_mxp & MXP_TELOPT)
+                new_mxp |= old_mxp & (MXP_TELOPT_SENT|MXP_TELOPT_ACTIVE);
+            else if (ip->tn_enabled
+                  && telopts_are_driver_owned
+                  && (old_mxp & (MXP_TELOPT_SENT|MXP_TELOPT_ACTIVE)))
+                send_telnet_option_to_interactive(ip, (char)DONT, (char)TELOPT_MXP);
+
+            if (new_mxp & MXP_PUEBLO)
+                new_mxp |= old_mxp & (MXP_PUEBLO_ACTIVE|MXP_PUEBLO_CHECKED);
+
+            ip->mxp = new_mxp;
+            request_mxp_telopt(ip);
+        }
         break;
 
 #ifdef USE_MCCP
@@ -9134,6 +9351,12 @@ f_interactive_info (svalue_t *sp)
         if (!ip)
             errorf("Default value for IC_TELNET_ENABLED is not supported.\n");
         put_number(&result, ip->tn_enabled != 0);
+        break;
+
+    case IC_MXP:
+        if (!ip)
+            errorf("Default value for IC_MXP is not supported.\n");
+        put_number(&result, ip->mxp & MXP_PUBLIC_MASK);
         break;
 
 #ifdef USE_MCCP

--- a/src/comm.c
+++ b/src/comm.c
@@ -876,6 +876,34 @@ set_socket_nonblocking (SOCKET_T new_socket)
 
 /*-------------------------------------------------------------------------*/
 static void
+write_socket_best_effort (SOCKET_T socket, const char *message, size_t length)
+
+/* Write as much of <message> as the nonblocking <socket> currently accepts.
+ * Retry interrupted writes and stop on any other error.
+ */
+
+{
+    int retries = 6;
+
+    while (length > 0)
+    {
+        ssize_t written = (ssize_t)socket_write(socket, message, length);
+
+        if (written > 0)
+        {
+            message += written;
+            length -= written;
+            retries = 6;
+        }
+        else if (written < 0 && errno == EINTR && --retries > 0)
+            continue;
+        else
+            break;
+    }
+} /* write_socket_best_effort() */
+
+/*-------------------------------------------------------------------------*/
+static void
 set_close_on_exec (SOCKET_T new_socket)
 
 /* Set that <new_socket> is closed when the driver performs an exec()
@@ -1299,7 +1327,7 @@ urgent_data_handler (int signo)
 
 {
     if (d_flag)
-        write(2, "received urgent data\n", 21);
+        write_bytes(2, "received urgent data\n", 21);
     urgent_data = MY_TRUE;
     urgent_data_time = current_time;
 }
@@ -2873,10 +2901,10 @@ get_message (char *buff, size_t *bufflength)
                     char buf[MAX_TEXT];
 #ifdef USE_TLS
                     if (ip->tls_status != TLS_INACTIVE)
-                        tls_read(ip, buf, MAX_TEXT);
+                        l = tls_read(ip, buf, MAX_TEXT);
                     else
 #endif
-                        socket_read(ip->socket, buf, MAX_TEXT);
+                        l = socket_read(ip->socket, buf, MAX_TEXT);
 
                     continue;
                 }
@@ -3312,7 +3340,8 @@ remove_interactive (object_t *ob, Bool force)
 
         erq_demon = interactive->socket;
         erq_proto_demon = -1;
-        socket_write(erq_demon, erq_welcome, sizeof erq_welcome);
+        write_socket_best_effort(erq_demon, (char *)erq_welcome,
+                                 sizeof erq_welcome);
     }
     else
 #endif
@@ -3589,8 +3618,8 @@ new_player ( object_t *ob, SOCKET_T new_socket
 
     if (message)
     {
-        socket_write(new_socket, message, strlen(message));
-        socket_write(new_socket, "\r\n", 2);
+        write_socket_best_effort(new_socket, message, strlen(message));
+        write_socket_best_effort(new_socket, "\r\n", 2);
         socket_close(new_socket);
         return;
     }
@@ -3609,12 +3638,12 @@ new_player ( object_t *ob, SOCKET_T new_socket
             string_t *msg;
 
             msg = driver_hook[H_NO_IPC_SLOT].u.str;
-            socket_write(new_socket, get_txt(msg), mstrsize(msg));
+            write_socket_best_effort(new_socket, get_txt(msg), mstrsize(msg));
         }
         else
         {
             message = "The mud is full. Come back later.\r\n";
-            socket_write(new_socket, message, strlen(message));
+            write_socket_best_effort(new_socket, message, strlen(message));
         }
         socket_close(new_socket);
         debug_message("%s Out of IPC slots for new connection.\n"
@@ -3627,7 +3656,7 @@ new_player ( object_t *ob, SOCKET_T new_socket
     if (O_IS_INTERACTIVE(master_ob))
     {
         message = "Cannot accept connections. Come back later.\r\n";
-        socket_write(new_socket, message, strlen(message));
+        write_socket_best_effort(new_socket, message, strlen(message));
         socket_close(new_socket);
         debug_message("%s Master still busy with previous new connection.\n"
                      , time_stamp());
@@ -3640,7 +3669,7 @@ new_player ( object_t *ob, SOCKET_T new_socket
     if (!new_interactive)
     {
         message = "Cannot accept connection (out of memory). Come back later.\r\n";
-        socket_write(new_socket, message, strlen(message));
+        write_socket_best_effort(new_socket, message, strlen(message));
         socket_close(new_socket);
         debug_message("%s Out of memory (%zu bytes) for new connection.\n"
                      , time_stamp(), sizeof(interactive_t));
@@ -3730,7 +3759,7 @@ new_player ( object_t *ob, SOCKET_T new_socket
             debug_message("%s Error setting up initial encoding: %s.\n", time_stamp(), strerror(errno));
 
         message = "Error setting up encoding.\r\n";
-        socket_write(new_socket, message, strlen(message));
+        write_socket_best_effort(new_socket, message, strlen(message));
         socket_close(new_socket);
 
         O_GET_INTERACTIVE(master_ob) = NULL;
@@ -4709,9 +4738,9 @@ send_telnet_option_to_interactive (interactive_t *ip, char action, char option)
 
 /*-------------------------------------------------------------------------*/
 static void
-request_mxp_telopt (interactive_t *ip)
+offer_mxp_telopt (interactive_t *ip)
 
-/* Request MXP telnet support from <ip>, if configured and possible.
+/* Offer MXP telnet support to <ip>, if configured and possible.
  */
 
 {
@@ -4720,10 +4749,10 @@ request_mxp_telopt (interactive_t *ip)
      && (ip->mxp & MXP_TELOPT)
      && !(ip->mxp & (MXP_TELOPT_SENT|MXP_TELOPT_ACTIVE)))
     {
-        send_telnet_option_to_interactive(ip, (char)DO, (char)TELOPT_MXP);
+        send_telnet_option_to_interactive(ip, (char)WILL, (char)TELOPT_MXP);
         ip->mxp |= MXP_TELOPT_SENT;
     }
-} /* request_mxp_telopt() */
+} /* offer_mxp_telopt() */
 
 /*-------------------------------------------------------------------------*/
 static bool
@@ -4757,7 +4786,7 @@ send_pueblo_html_mode (interactive_t *ip)
  */
 
 {
-    static const char mode[] = "</xch_mudtext><xch_mode=html>";
+    static const char mode[] = "</xch_mudtext><img xch_mode=html>";
 
     send_bytes_to_interactive(ip, mode, sizeof(mode) - 1);
 } /* send_pueblo_html_mode() */
@@ -4968,32 +4997,31 @@ mxp_telnet_neg (int option)
 
     switch (ip->tn_state)
     {
-    case TS_WILL:
+    case TS_DO:
         if (ip->mxp & MXP_TELOPT)
         {
             if (!(ip->mxp & MXP_TELOPT_SENT))
             {
-                send_do(option);
+                send_will(option);
                 ip->mxp |= MXP_TELOPT_SENT;
             }
             ip->mxp |= MXP_TELOPT_ACTIVE;
         }
         else
         {
-            send_dont(option);
+            send_wont(option);
         }
-        break;
-
-    case TS_WONT:
-        ip->mxp &= ~(MXP_TELOPT_SENT|MXP_TELOPT_ACTIVE);
-        break;
-
-    case TS_DO:
-        send_wont(option);
         break;
 
     case TS_DONT:
         ip->mxp &= ~(MXP_TELOPT_SENT|MXP_TELOPT_ACTIVE);
+        break;
+
+    case TS_WILL:
+        send_dont(option);
+        break;
+
+    case TS_WONT:
         break;
     }
 } /* mxp_telnet_neg() */
@@ -5934,6 +5962,7 @@ start_erq_demon (const char *suffix, size_t suffixlen)
     int sockets[2];
     int pid, i;
     char c = 0;
+    ssize_t received;
 
     /* Create the freelist in pending_erq[] */
     pending_erq[0].fun.type = T_INVALID;
@@ -5969,8 +5998,12 @@ start_erq_demon (const char *suffix, size_t suffixlen)
     if ((pid = fork()) == 0)
     {
         /* Child */
-        dup2(sockets[0], 0);
-        dup2(sockets[0], 1);
+        if (dup2(sockets[0], 0) < 0 || dup2(sockets[0], 1) < 0)
+        {
+            write_bytes(sockets[0], "0", 1);
+            _exit(1);
+        }
+
         close(sockets[0]);
         close(sockets[1]);
 
@@ -5982,7 +6015,7 @@ start_erq_demon (const char *suffix, size_t suffixlen)
             else
                 execl((char *)path, "erq", "--forked", (char*)0);
         }
-        write(1, "0", 1);  /* indicate failure back to the driver */
+        write_bytes(1, "0", 1);  /* indicate failure back to the driver */
         _exit(1);
     }
 
@@ -6009,8 +6042,11 @@ start_erq_demon (const char *suffix, size_t suffixlen)
     /* Read the first character from the ERQ. If it's '0', the ERQ
      * didn't start.
      */
-    read(sockets[1], &c, 1);
-    if (c == '0') {
+    do
+        received = read(sockets[1], &c, 1);
+    while (received < 0 && errno == EINTR);
+
+    if (received != 1 || c == '0') {
         close(sockets[1]);
 
         printf("%s Failed to start erq.\n", time_stamp());
@@ -9050,7 +9086,7 @@ f_configure_interactive (svalue_t *sp)
 
         ip->tn_enabled = (sp->u.number != 0);
         if (ip->tn_enabled)
-            request_mxp_telopt(ip);
+            offer_mxp_telopt(ip);
         else
             ip->mxp &= ~(MXP_TELOPT_SENT|MXP_TELOPT_ACTIVE);
         break;
@@ -9076,13 +9112,13 @@ f_configure_interactive (svalue_t *sp)
             else if (ip->tn_enabled
                   && telopts_are_driver_owned
                   && (old_mxp & (MXP_TELOPT_SENT|MXP_TELOPT_ACTIVE)))
-                send_telnet_option_to_interactive(ip, (char)DONT, (char)TELOPT_MXP);
+                send_telnet_option_to_interactive(ip, (char)WONT, (char)TELOPT_MXP);
 
             if (new_mxp & MXP_PUEBLO)
                 new_mxp |= old_mxp & (MXP_PUEBLO_ACTIVE|MXP_PUEBLO_CHECKED);
 
             ip->mxp = new_mxp;
-            request_mxp_telopt(ip);
+            offer_mxp_telopt(ip);
         }
         break;
 

--- a/src/comm.h
+++ b/src/comm.h
@@ -204,6 +204,7 @@ struct interactive_s {
 
     CBool closing;              /* True when closing this socket. */
     CBool tn_enabled;           /* True: telnet machine enabled */
+    char mxp;                   /* MXP/Pueblo requested and active state. */
     char do_close;              /* Bitflags: Close this down; Proto-ERQ. */
     char noecho;                /* Input mode bitflags */
 

--- a/src/files.c
+++ b/src/files.c
@@ -244,13 +244,62 @@ struct xdirect
     int   mode;
 };
 
-#define XOPENDIR(dest, path) (\
-    (!chdir(path) &&\
-    NULL != ((dest) = opendir("."))) ||\
-        (chdir(mud_lib),MY_FALSE)\
-)
+/*-------------------------------------------------------------------------*/
+static void
+restore_mudlib_directory (void)
 
-#define xclosedir(dir_ptr)   (chdir(mud_lib),closedir(dir_ptr))
+/* Restore the process working directory after directory operations.
+ */
+
+{
+    if (chdir(mud_lib) < 0)
+        fatal("Could not restore mudlib directory '%s': %s.\n",
+              mud_lib, strerror(errno));
+} /* restore_mudlib_directory() */
+
+/*-------------------------------------------------------------------------*/
+static Bool
+xopendir (DIR **dest, const char *path)
+
+/* Change into <path> and open it. On failure, restore the mudlib working
+ * directory and preserve the original error.
+ */
+
+{
+    int errorno;
+
+    if (chdir(path) < 0)
+    {
+        errorno = errno;
+    }
+    else
+    {
+        *dest = opendir(".");
+        if (*dest != NULL)
+            return MY_TRUE;
+        errorno = errno;
+    }
+
+    restore_mudlib_directory();
+    errno = errorno;
+    return MY_FALSE;
+} /* xopendir() */
+
+/*-------------------------------------------------------------------------*/
+static void
+xclosedir (DIR *dir_ptr)
+
+/* Restore the mudlib working directory and close <dir_ptr>.
+ */
+
+{
+    restore_mudlib_directory();
+    if (closedir(dir_ptr) < 0)
+        debug_message("%s Could not close directory: %s.\n",
+                      time_stamp(), strerror(errno));
+} /* xclosedir() */
+
+#define XOPENDIR(dest, path) xopendir(&(dest), path)
 #define xrewinddir(dir_ptr)  rewinddir(dir_ptr)
 #define XDIR DIR
 
@@ -2030,8 +2079,19 @@ v_write_file (svalue_t *sp, int num_arg)
                     atend = true;
                 }
 
-                if (outbufptr != outbuf)
-                    fwrite(outbuf, outbufptr - outbuf, 1, f);
+                if (outbufptr != outbuf
+                 && fwrite(outbuf, outbufptr - outbuf, 1, f) != 1)
+                {
+                    int err = errno;
+
+                    mb_free(mbFile);
+                    fclose(f);
+                    if (err)
+                        errorf("Could not write file: (%d) %s.\n",
+                               err, strerror(err));
+                    else
+                        errorf("Could not write complete file contents.\n");
+                }
 
                 if (res == (size_t)-1)
                 {

--- a/src/gcollect.c
+++ b/src/gcollect.c
@@ -2767,12 +2767,12 @@ show_string (int d, char *block, int depth UNUSED)
         WRITES(d, "\"");
         if ((len = strlen(block)) < 70)
         {
-            write(d, block, len);
+            write_bytes(d, block, len);
             WRITES(d, "\"");
         }
         else
         {
-            write(d, block, 50);
+            write_bytes(d, block, 50);
             WRITES(d, "\" (truncated, length ");writed(d, len);WRITES(d, ")");
         }
     }
@@ -2797,12 +2797,12 @@ show_mstring_data (int d, void *block, int depth UNUSED)
     WRITES(d, ")\"");
     if (str->size < 50)
     {
-        write(d, str->txt, str->size);
+        write_bytes(d, str->txt, str->size);
         WRITES(d, "\"");
     }
     else
     {
-        write(d, str->txt, 50);
+        write_bytes(d, str->txt, 50);
         WRITES(d, "\" (truncated)");
     }
 } /* show_mstring_data() */

--- a/src/main.c
+++ b/src/main.c
@@ -818,6 +818,35 @@ debug_message(const char *a, ...)
 
 /*-------------------------------------------------------------------------*/
 void
+write_bytes (int d, const char *s, size_t length)
+
+/* Memory-safe best-effort function to write <length> bytes from <s> to
+ * descriptor <d>. Complete partial writes and retry interrupted writes.
+ */
+
+{
+    int saved_errno = errno;
+
+    while (length > 0)
+    {
+        ssize_t written = write(d, s, length);
+
+        if (written > 0)
+        {
+            s += written;
+            length -= written;
+        }
+        else if (written < 0 && errno == EINTR)
+            continue;
+        else
+            break;
+    }
+
+    errno = saved_errno;
+} /* write_bytes() */
+
+/*-------------------------------------------------------------------------*/
+void
 write_x (int d, p_uint i)
 
 /* Memory safe function to write 4-byte hexvalue <i> to fd <d>. */
@@ -830,7 +859,7 @@ write_x (int d, p_uint i)
         c = (char)((i >> (8 * sizeof i - 4) ) + '0');
         if (c >= '9' + 1)
             c += (char)('a' - ('9' + 1));
-        write(d, &c, 1);
+        write_bytes(d, &c, 1);
     }
 } /* write_x() */
 
@@ -848,7 +877,7 @@ write_X (int d, unsigned char i)
         c = (char)((i >> (8 * sizeof i - 4) ) + '0');
         if (c >= '9' + 1)
             c += (char)('a' - ('9' + 1));
-        write(d, &c, 1);
+        write_bytes(d, &c, 1);
     }
 } /* write_X() */
 
@@ -866,7 +895,7 @@ writed (int d, p_uint i)
     if (!j) j = 1;
     do {
         c = (char)((i / j) % 10 + '0');
-        write(d, &c, 1);
+        write_bytes(d, &c, 1);
         j /= 10;
     } while (j > 0);
 } /* writed() */
@@ -878,7 +907,7 @@ writes (int d, const char *s)
 /* Memory safe function to string <s> to fd <d>. */
 
 {
-    write(d, s, strlen(s));
+    write_bytes(d, s, strlen(s));
 }
 
 /*-------------------------------------------------------------------------*/
@@ -899,23 +928,23 @@ dprintf_first (int fd, char *s, p_int a)
     do {
         if ( !(p = strchr(s, '%')) )
         {
-            write(fd, s, strlen(s));
+            writes(fd, s);
             return "";
         }
 
-        write(fd, s, p - s);
+        write_bytes(fd, s, p - s);
         switch(p[1])
         {
         case '%':
-            write(fd, p+1, 1);
+            write_bytes(fd, p+1, 1);
             continue;
         case 's':
-            write(fd, (char *)a, strlen((char*)a));
+            writes(fd, (char *)a);
             break;
         case 'c':
           {
             char c = (char)a;
-            write(fd, (char *)&c, 1);
+            write_bytes(fd, (char *)&c, 1);
             break;
           }
         case 'd':
@@ -942,7 +971,7 @@ dprintf1 (int fd, char *s, p_int a)
 
 {
     s = dprintf_first(fd, s, a);
-    write(fd, s, strlen(s));
+    writes(fd, s);
 } /* dprintf1() */
 
 /*-------------------------------------------------------------------------*/
@@ -3028,8 +3057,15 @@ eval_arg (int eOption, const char * pValue)
             int n;
 
             n = strtol(pValue, (char **)0, 0);
-            while(--n >= 0) {
-                (void)dup(2);
+            while (--n >= 0)
+            {
+                if (dup(2) < 0)
+                {
+                    fprintf(stderr,
+                            "Could not gobble another file descriptor: %s.\n",
+                            strerror(errno));
+                    return hrError;
+                }
             }
             break;
         }

--- a/src/main.h
+++ b/src/main.h
@@ -61,6 +61,7 @@ extern void initialize_master_uid(void);
 extern void debug_message(const char *, ...) FORMATDEBUG(printf, 1, 2);
 extern void vdebug_message(const char *, va_list) FORMATDEBUG(printf, 1, 0);
 
+extern void write_bytes(int d, const char *s, size_t length);
 extern void write_X (int d, unsigned char i);
 extern void write_x(int d, p_uint i);
 extern void writed(int d, p_uint i);

--- a/src/make_func.y
+++ b/src/make_func.y
@@ -2763,7 +2763,8 @@ yylex1 (void)
             int line;
             char file[MAXPATHLEN+1];
 
-            fgets(line_buffer, MAKE_FUNC_MAXLINE, fpr);
+            if (fgets(line_buffer, MAKE_FUNC_MAXLINE, fpr) == NULL)
+                yyerror("End of file after '#' directive");
             if ( sscanf(line_buffer, "%d \"%s\"",&line,file ) == 2 )
             {
                 current_line = line+1;
@@ -2798,7 +2799,8 @@ yylex1 (void)
                 return END;
             }
             send_end = 1;
-            fgets(line_buffer, MAKE_FUNC_MAXLINE, fpr);
+            if (fgets(line_buffer, MAKE_FUNC_MAXLINE, fpr) == NULL)
+                yyerror("End of file after '%' directive");
             current_line++;
             if (parsetype == PARSE_FUNC_SPEC)
             {

--- a/src/slaballoc.c
+++ b/src/slaballoc.c
@@ -446,7 +446,7 @@ static word_t samagic[]
 
 #ifdef DEBUG_MALLOC_ALLOCS
 #    define ulog(s) \
-       write(gcollect_outfd, s, strlen(s))
+       writes(gcollect_outfd, s)
 #    define ulog1f(s,t) \
        dprintf1(gcollect_outfd, s, (p_int)(t))
 #    define ulog2f(s,t1,t2) \

--- a/src/smalloc.c
+++ b/src/smalloc.c
@@ -475,7 +475,7 @@ static word_t samagic[]
 
 #ifdef DEBUG_MALLOC_ALLOCS
 #    define ulog(s) \
-       write(gcollect_outfd, s, strlen(s))
+       writes(gcollect_outfd, s)
 #    define ulog1f(s,t) \
        dprintf1(gcollect_outfd, s, (p_int)(t))
 #    define ulog2f(s,t1,t2) \

--- a/src/swap.c
+++ b/src/swap.c
@@ -2296,7 +2296,8 @@ load_ob_from_swap (object_t *ob)
             return result | -0x80;
         }
 
-        fread(block, size, 1, swap_file);
+        if (size > 0 && fread(block, size, 1, swap_file) != 1)
+            fatal("Couldn't read the swap file.\n");
 
         /* Prepare to restore */
         set_current_object(&dummy);
@@ -2406,8 +2407,9 @@ load_line_numbers_from_swap (program_t *prog)
 
     if (tmp_numbers.size > sizeof(tmp_numbers))
     {
-        fread(lines+1, tmp_numbers.size - sizeof(tmp_numbers)
-             , 1, swap_file);
+        if (fread(lines+1, tmp_numbers.size - sizeof(tmp_numbers),
+                  1, swap_file) != 1)
+            fatal("Couldn't read the swap file.\n");
     }
 
     prog->line_numbers = lines;

--- a/src/xalloc.c
+++ b/src/xalloc.c
@@ -22,6 +22,7 @@
 #include "backend.h"
 #include "gcollect.h"
 #include "interpret.h"
+#include "main.h"
 #include "simulate.h"
 
 #include "exec.h"
@@ -1059,7 +1060,7 @@ print_block (int d, word_t *block)
          && dispatch_table[i].line == line)
         {
             (*dispatch_table[i].func)(d, (char *)(block+XM_OVERHEAD), 0);
-            write(d, "\n", 1);
+            write_bytes(d, "\n", 1);
             return;
         }
     }
@@ -1092,7 +1093,7 @@ print_block (int d, word_t *block)
             for (i = 0; i < 16 && i < (int)size && i < limit; i++)
             {
                 if (isprint((unsigned char)cp[i]))
-                    write(d, cp+i, 1);
+                    write_bytes(d, cp+i, 1);
                 else
                     writes(d, ".");
             }
@@ -1655,7 +1656,6 @@ reallocate_reserved_areas (void)
  */
 
 {
-    char *p;
     malloc_privilege = MALLOC_USER;
     if (reserved_system_size && !reserved_system_area) {
         if ( !(reserved_system_area = xalloc((size_t)reserved_system_size)) ) {
@@ -1663,8 +1663,7 @@ reallocate_reserved_areas (void)
             return;
         }
         else {
-            p = "Reallocated System reserve.\n";
-            write(1, p, strlen(p));
+            writes(1, "Reallocated System reserve.\n");
         }
     }
     if (reserved_master_size && !reserved_master_area) {
@@ -1673,8 +1672,7 @@ reallocate_reserved_areas (void)
             return;
         }
         else {
-            p = "Reallocated Master reserve.\n";
-            write(1, p, strlen(p));
+            writes(1, "Reallocated Master reserve.\n");
         }
     }
     if (reserved_user_size && !reserved_user_area) {
@@ -1683,8 +1681,7 @@ reallocate_reserved_areas (void)
             return;
         }
         else {
-            p = "Reallocated User reserve.\n";
-            write(1, p, strlen(p));
+            writes(1, "Reallocated User reserve.\n");
         }
     }
     slow_shut_down_to_do = 0;

--- a/test/t-mxp-pueblo-initial-line.c
+++ b/test/t-mxp-pueblo-initial-line.c
@@ -8,10 +8,22 @@
  */
 
 object client;
+int test_failed;
+
+void record_failure()
+{
+    test_failed = 1;
+}
+
+int has_failed()
+{
+    return test_failed;
+}
 
 void fail(string text)
 {
     msg("FAILURE: %s\n", text);
+    __MASTER_OBJECT__->record_failure();
     shutdown(1);
 }
 
@@ -33,6 +45,7 @@ object get_client()
 void timeout()
 {
     msg("FAILURE: Timed out.\n");
+    __MASTER_OBJECT__->record_failure();
     shutdown(1);
 }
 
@@ -44,6 +57,7 @@ void receive_second_command(string str)
     {
         msg("FAILURE: Server received %O instead of %O.\n",
             str, "PUEBLOCLIENT 2.50");
+        __MASTER_OBJECT__->record_failure();
         shutdown(1);
     }
 
@@ -52,6 +66,7 @@ void receive_second_command(string str)
     {
         msg("FAILURE: MXP state is 0x%x instead of 0x%x.\n",
             state, MXP_PUEBLO);
+        __MASTER_OBJECT__->record_failure();
         shutdown(1);
     }
 
@@ -63,6 +78,7 @@ void receive_first_command(string str)
     if (str != "hello")
     {
         msg("FAILURE: Server received %O instead of %O.\n", str, "hello");
+        __MASTER_OBJECT__->record_failure();
         shutdown(1);
     }
 
@@ -75,11 +91,15 @@ void receive_client_line(string str)
     if (str != "READY")
     {
         msg("FAILURE: Client received %O instead of %O.\n", str, "READY");
+        __MASTER_OBJECT__->record_failure();
         shutdown(1);
     }
 
-    msg("Success.\n");
-    shutdown(0);
+    if (!__MASTER_OBJECT__->has_failed())
+    {
+        msg("Success.\n");
+        shutdown(0);
+    }
 }
 
 void send_client_protocol()

--- a/test/t-mxp-pueblo-initial-line.c
+++ b/test/t-mxp-pueblo-initial-line.c
@@ -1,0 +1,122 @@
+#pragma save_types, rtt_checks
+
+#include "/inc/base.inc"
+#include "/inc/client.inc"
+
+/* This test covers the Pueblo response being limited to the connection's
+ * initial line. A later PUEBLOCLIENT command must be delivered normally.
+ */
+
+object client;
+
+void fail(string text)
+{
+    msg("FAILURE: %s\n", text);
+    shutdown(1);
+}
+
+bytes b(string s)
+{
+    return to_bytes(s, "ISO-8859-1");
+}
+
+void set_client(object ob)
+{
+    client = ob;
+}
+
+object get_client()
+{
+    return client;
+}
+
+void timeout()
+{
+    msg("FAILURE: Timed out.\n");
+    shutdown(1);
+}
+
+void receive_second_command(string str)
+{
+    int state;
+
+    if (str != "PUEBLOCLIENT 2.50")
+    {
+        msg("FAILURE: Server received %O instead of %O.\n",
+            str, "PUEBLOCLIENT 2.50");
+        shutdown(1);
+    }
+
+    state = interactive_info(this_object(), IC_MXP);
+    if (state != MXP_PUEBLO)
+    {
+        msg("FAILURE: MXP state is 0x%x instead of 0x%x.\n",
+            state, MXP_PUEBLO);
+        shutdown(1);
+    }
+
+    write("READY\n");
+}
+
+void receive_first_command(string str)
+{
+    if (str != "hello")
+    {
+        msg("FAILURE: Server received %O instead of %O.\n", str, "hello");
+        shutdown(1);
+    }
+
+    configure_interactive(this_object(), IC_MXP, MXP_PUEBLO);
+    input_to("receive_second_command");
+}
+
+void receive_client_line(string str)
+{
+    if (str != "READY")
+    {
+        msg("FAILURE: Client received %O instead of %O.\n", str, "READY");
+        shutdown(1);
+    }
+
+    msg("Success.\n");
+    shutdown(0);
+}
+
+void send_client_protocol()
+{
+    binary_message(b("hello\r\nPUEBLOCLIENT 2.50\r\n"));
+}
+
+void run_server()
+{
+    object cl;
+
+    input_to("receive_first_command");
+
+    cl = __MASTER_OBJECT__->get_client();
+    if (!cl)
+        fail("Client object was not registered.");
+    cl->send_client_protocol();
+    call_out("timeout", 2 * __ALARM_TIME__);
+}
+
+void run_client()
+{
+    __MASTER_OBJECT__->set_client(this_object());
+    input_to("receive_client_line");
+    call_out("timeout", 2 * __ALARM_TIME__);
+}
+
+void run_test()
+{
+    msg("\nRunning test for Pueblo initial-line detection:\n"
+          "-----------------------------------------------\n");
+
+    connect_self("run_server", "run_client");
+}
+
+string *epilog(int eflag)
+{
+    run_test();
+    return 0;
+}

--- a/test/t-mxp-pueblo-mudlib-telopts.c
+++ b/test/t-mxp-pueblo-mudlib-telopts.c
@@ -2,6 +2,7 @@
 
 #include "/inc/base.inc"
 #include "/inc/client.inc"
+#include "/inc/deep_eq.inc"
 
 #include "/sys/input_to.h"
 #include "/sys/telnet.h"
@@ -13,10 +14,16 @@
 
 int server_done;
 int client_done;
-string html_expected = "</xch_mudtext><xch_mode=html>";
+int test_failed;
+string html_expected = "</xch_mudtext><img xch_mode=html>";
 object client;
 
 void check_done();
+
+void record_failure()
+{
+    test_failed = 1;
+}
 
 void set_client(object ob)
 {
@@ -31,6 +38,7 @@ object get_client()
 void fail(string text)
 {
     msg("FAILURE: %s\n", text);
+    __MASTER_OBJECT__->record_failure();
     shutdown(1);
 }
 
@@ -57,7 +65,7 @@ void client_success()
 
 void check_done()
 {
-    if (server_done && client_done)
+    if (!test_failed && server_done && client_done)
     {
         msg("Success.\n");
         shutdown(0);
@@ -68,6 +76,7 @@ void timeout()
 {
     msg("FAILURE: Timed out, server_done=%d, client_done=%d.\n",
         server_done, client_done);
+    __MASTER_OBJECT__->record_failure();
     shutdown(1);
 }
 
@@ -79,6 +88,7 @@ void receive_server_command(string str)
     if (str != "look")
     {
         msg("FAILURE: Server received %O instead of %O.\n", str, "look");
+        __MASTER_OBJECT__->record_failure();
         shutdown(1);
     }
 
@@ -87,6 +97,7 @@ void receive_server_command(string str)
     if (state != expected)
     {
         msg("FAILURE: MXP state is 0x%x instead of 0x%x.\n", state, expected);
+        __MASTER_OBJECT__->record_failure();
         shutdown(1);
     }
 
@@ -106,6 +117,7 @@ void receive_client_line(string str)
     {
         msg("FAILURE: Client received %O instead of %O.\n",
             received, expected);
+        __MASTER_OBJECT__->record_failure();
         shutdown(1);
     }
 

--- a/test/t-mxp-pueblo-mudlib-telopts.c
+++ b/test/t-mxp-pueblo-mudlib-telopts.c
@@ -1,0 +1,163 @@
+#pragma save_types, rtt_checks
+
+#include "/inc/base.inc"
+#include "/inc/client.inc"
+
+#include "/sys/input_to.h"
+#include "/sys/telnet.h"
+
+/* This test covers MXP/Pueblo support when H_NOECHO makes telnet
+ * negotiation mudlib-owned. The driver must not negotiate TELOPT_MXP,
+ * but Pueblo response detection remains driver-assisted.
+ */
+
+int server_done;
+int client_done;
+string html_expected = "</xch_mudtext><xch_mode=html>";
+object client;
+
+void check_done();
+
+void set_client(object ob)
+{
+    client = ob;
+}
+
+object get_client()
+{
+    return client;
+}
+
+void fail(string text)
+{
+    msg("FAILURE: %s\n", text);
+    shutdown(1);
+}
+
+bytes b(string s)
+{
+    return to_bytes(s, "ISO-8859-1");
+}
+
+void noecho(int flag, object ob, int noecho)
+{
+}
+
+void server_success()
+{
+    server_done = 1;
+    check_done();
+}
+
+void client_success()
+{
+    client_done = 1;
+    check_done();
+}
+
+void check_done()
+{
+    if (server_done && client_done)
+    {
+        msg("Success.\n");
+        shutdown(0);
+    }
+}
+
+void timeout()
+{
+    msg("FAILURE: Timed out, server_done=%d, client_done=%d.\n",
+        server_done, client_done);
+    shutdown(1);
+}
+
+void receive_server_command(string str)
+{
+    int state;
+    int expected;
+
+    if (str != "look")
+    {
+        msg("FAILURE: Server received %O instead of %O.\n", str, "look");
+        shutdown(1);
+    }
+
+    state = interactive_info(this_object(), IC_MXP);
+    expected = MXP_TELOPT | MXP_PUEBLO | MXP_PUEBLO_ACTIVE;
+    if (state != expected)
+    {
+        msg("FAILURE: MXP state is 0x%x instead of 0x%x.\n", state, expected);
+        shutdown(1);
+    }
+
+    write("READY\n");
+    __MASTER_OBJECT__->server_success();
+}
+
+void receive_client_line(string str)
+{
+    int *received;
+    int *expected;
+
+    received = to_array(b(str));
+    expected = to_array(b(html_expected + "READY"));
+
+    if (!deep_eq(received, expected))
+    {
+        msg("FAILURE: Client received %O instead of %O.\n",
+            received, expected);
+        shutdown(1);
+    }
+
+    __MASTER_OBJECT__->client_success();
+}
+
+void send_client_protocol()
+{
+    binary_message(b("PUEBLOCLIENT 2.50\r\nlook\r\n"));
+}
+
+void enable_telnet()
+{
+    object cl;
+
+    configure_interactive(this_object(), IC_TELNET_ENABLED, 1);
+
+    cl = __MASTER_OBJECT__->get_client();
+    if (!cl)
+        fail("Client object was not registered.");
+    cl->send_client_protocol();
+}
+
+void run_server()
+{
+    configure_interactive(this_object(), IC_MXP, MXP_TELOPT | MXP_PUEBLO);
+    if (interactive_info(this_object(), IC_MXP) != (MXP_TELOPT | MXP_PUEBLO))
+        fail("Initial MXP request state is wrong.");
+
+    input_to("receive_server_command");
+    call_out("enable_telnet", 0);
+    call_out("timeout", 2 * __ALARM_TIME__);
+}
+
+void run_client()
+{
+    __MASTER_OBJECT__->set_client(this_object());
+    input_to("receive_client_line");
+    call_out("timeout", 2 * __ALARM_TIME__);
+}
+
+void run_test()
+{
+    msg("\nRunning test for MXP/Pueblo with mudlib telopts:\n"
+          "------------------------------------------------\n");
+
+    connect_self("run_server", "run_client");
+}
+
+string *epilog(int eflag)
+{
+    set_driver_hook(H_NOECHO, "noecho");
+    run_test();
+    return 0;
+}

--- a/test/t-mxp-pueblo.c
+++ b/test/t-mxp-pueblo.c
@@ -2,6 +2,7 @@
 
 #include "/inc/base.inc"
 #include "/inc/client.inc"
+#include "/inc/deep_eq.inc"
 
 #include "/sys/input_to.h"
 #include "/sys/telnet.h"
@@ -14,10 +15,16 @@
 
 int server_done;
 int client_done;
-string html_expected = "</xch_mudtext><xch_mode=html>";
+int test_failed;
+string html_expected = "</xch_mudtext><img xch_mode=html>";
 object client;
 
 void check_done();
+
+void record_failure()
+{
+    test_failed = 1;
+}
 
 void set_client(object ob)
 {
@@ -32,6 +39,7 @@ object get_client()
 void fail(string text)
 {
     msg("FAILURE: %s\n", text);
+    __MASTER_OBJECT__->record_failure();
     shutdown(1);
 }
 
@@ -72,7 +80,7 @@ void client_success()
 
 void check_done()
 {
-    if (server_done && client_done)
+    if (!test_failed && server_done && client_done)
     {
         msg("Success.\n");
         shutdown(0);
@@ -83,6 +91,7 @@ void timeout()
 {
     msg("FAILURE: Timed out, server_done=%d, client_done=%d.\n",
         server_done, client_done);
+    __MASTER_OBJECT__->record_failure();
     shutdown(1);
 }
 
@@ -94,6 +103,7 @@ void receive_server_command(string str)
     if (str != "look")
     {
         msg("FAILURE: Server received %O instead of %O.\n", str, "look");
+        __MASTER_OBJECT__->record_failure();
         shutdown(1);
     }
 
@@ -103,6 +113,18 @@ void receive_server_command(string str)
     if (state != expected)
     {
         msg("FAILURE: MXP state is 0x%x instead of 0x%x.\n", state, expected);
+        __MASTER_OBJECT__->record_failure();
+        shutdown(1);
+    }
+
+    configure_interactive(this_object(), IC_MXP, MXP_PUEBLO);
+    state = interactive_info(this_object(), IC_MXP);
+    expected = MXP_PUEBLO | MXP_PUEBLO_ACTIVE;
+    if (state != expected)
+    {
+        msg("FAILURE: MXP state after disabling telopt is 0x%x instead of 0x%x.\n",
+            state, expected);
+        __MASTER_OBJECT__->record_failure();
         shutdown(1);
     }
 
@@ -115,13 +137,17 @@ void receive_client_line(string str)
     int *received;
     int *expected;
 
+    /* The peer driver consumes telnet option triplets before input_to().
+     * The server-side IC_MXP checks above cover negotiation state.
+     */
     received = to_array(b(str));
-    expected = ({ IAC, DO, TELOPT_MXP }) + to_array(b(html_expected + "READY"));
+    expected = to_array(b(html_expected + "READY"));
 
     if (!deep_eq(received, expected))
     {
         msg("FAILURE: Client received %O instead of %O.\n",
             received, expected);
+        __MASTER_OBJECT__->record_failure();
         shutdown(1);
     }
 
@@ -130,7 +156,7 @@ void receive_client_line(string str)
 
 void send_client_protocol()
 {
-    binary_message(({ IAC, WILL, TELOPT_MXP }));
+    binary_message(({ IAC, DO, TELOPT_MXP }));
     binary_message(b("PUEBLOCLIENT 2.50\r\nlook\r\n"));
 }
 

--- a/test/t-mxp-pueblo.c
+++ b/test/t-mxp-pueblo.c
@@ -1,0 +1,181 @@
+#pragma save_types, rtt_checks
+
+#include "/inc/base.inc"
+#include "/inc/client.inc"
+
+#include "/sys/input_to.h"
+#include "/sys/telnet.h"
+
+/* This test covers driver-side MXP telnet negotiation and the legacy
+ * Pueblo client response. The driver should negotiate capability and
+ * consume the Pueblo identification line, but leave markup generation
+ * to the mudlib.
+ */
+
+int server_done;
+int client_done;
+string html_expected = "</xch_mudtext><xch_mode=html>";
+object client;
+
+void check_done();
+
+void set_client(object ob)
+{
+    client = ob;
+}
+
+object get_client()
+{
+    return client;
+}
+
+void fail(string text)
+{
+    msg("FAILURE: %s\n", text);
+    shutdown(1);
+}
+
+bytes b(string s)
+{
+    return to_bytes(s, "ISO-8859-1");
+}
+
+void expect_error(mixed err, string name)
+{
+    if (!err)
+        fail(name + " did not raise an error.");
+}
+
+void negative_checks()
+{
+    expect_error(catch(configure_interactive(this_object(), IC_MXP,
+        MXP_TELOPT_ACTIVE)), "active MXP bit");
+    expect_error(catch(configure_interactive(this_object(), IC_MXP,
+        MXP_TELOPT | 0x100)), "unknown MXP bit");
+    expect_error(catch(configure_interactive(0, IC_MXP, 0)),
+        "default IC_MXP configuration");
+    expect_error(catch(interactive_info(0, IC_MXP)),
+        "default IC_MXP query");
+}
+
+void server_success()
+{
+    server_done = 1;
+    check_done();
+}
+
+void client_success()
+{
+    client_done = 1;
+    check_done();
+}
+
+void check_done()
+{
+    if (server_done && client_done)
+    {
+        msg("Success.\n");
+        shutdown(0);
+    }
+}
+
+void timeout()
+{
+    msg("FAILURE: Timed out, server_done=%d, client_done=%d.\n",
+        server_done, client_done);
+    shutdown(1);
+}
+
+void receive_server_command(string str)
+{
+    int state;
+    int expected;
+
+    if (str != "look")
+    {
+        msg("FAILURE: Server received %O instead of %O.\n", str, "look");
+        shutdown(1);
+    }
+
+    state = interactive_info(this_object(), IC_MXP);
+    expected = MXP_TELOPT | MXP_PUEBLO
+             | MXP_TELOPT_ACTIVE | MXP_PUEBLO_ACTIVE;
+    if (state != expected)
+    {
+        msg("FAILURE: MXP state is 0x%x instead of 0x%x.\n", state, expected);
+        shutdown(1);
+    }
+
+    write("READY\n");
+    __MASTER_OBJECT__->server_success();
+}
+
+void receive_client_line(string str)
+{
+    int *received;
+    int *expected;
+
+    received = to_array(b(str));
+    expected = ({ IAC, DO, TELOPT_MXP }) + to_array(b(html_expected + "READY"));
+
+    if (!deep_eq(received, expected))
+    {
+        msg("FAILURE: Client received %O instead of %O.\n",
+            received, expected);
+        shutdown(1);
+    }
+
+    __MASTER_OBJECT__->client_success();
+}
+
+void send_client_protocol()
+{
+    binary_message(({ IAC, WILL, TELOPT_MXP }));
+    binary_message(b("PUEBLOCLIENT 2.50\r\nlook\r\n"));
+}
+
+void enable_telnet()
+{
+    object cl;
+
+    configure_interactive(this_object(), IC_TELNET_ENABLED, 1);
+
+    cl = __MASTER_OBJECT__->get_client();
+    if (!cl)
+        fail("Client object was not registered.");
+    cl->send_client_protocol();
+}
+
+void run_server()
+{
+    negative_checks();
+
+    configure_interactive(this_object(), IC_MXP, MXP_TELOPT | MXP_PUEBLO);
+    if (interactive_info(this_object(), IC_MXP) != (MXP_TELOPT | MXP_PUEBLO))
+        fail("Initial MXP request state is wrong.");
+
+    input_to("receive_server_command");
+    call_out("enable_telnet", 0);
+    call_out("timeout", 2 * __ALARM_TIME__);
+}
+
+void run_client()
+{
+    __MASTER_OBJECT__->set_client(this_object());
+    input_to("receive_client_line");
+    call_out("timeout", 2 * __ALARM_TIME__);
+}
+
+void run_test()
+{
+    msg("\nRunning test for MXP/Pueblo support:\n"
+          "------------------------------------\n");
+
+    connect_self("run_server", "run_client");
+}
+
+string *epilog(int eflag)
+{
+    run_test();
+    return 0;
+}


### PR DESCRIPTION
Add driver-assisted MXP and Pueblo detection for interactives, configured with configure_interactive(IC_MXP) and queried with interactive_info(IC_MXP). MXP_TELOPT makes the driver offer IAC WILL TELOPT_MXP once the telnet machine is enabled and records the client's acknowledgement as MXP_TELOPT_ACTIVE. MXP_PUEBLO recognizes an initial PUEBLOCLIENT response line, consumes it, marks MXP_PUEBLO_ACTIVE and sends the Pueblo HTML-mode switch sequence. If the mudlib handles telnet negotiation itself, the request bits are only stored and the driver stays out of the negotiation.

The second commit also hardens I/O handling that surfaced while testing: connection greetings and refusal messages go through a best-effort socket writer that completes partial writes and retries EINTR, previously ignored fscanf/fgets/read/write results are checked, and write_file() reports write errors instead of failing silently.

Tests cover the telnet option negotiation, the initial Pueblo client response line, and mudlibs doing their own telnet negotiation (t-mxp-pueblo, t-mxp-pueblo-initial-line, t-mxp-pueblo-mudlib-telopts).