### PR TITLE
driver: fix compilation with DEBUG disabled

### DIFF
--- a/src/closure.c
+++ b/src/closure.c
@@ -5850,7 +5850,9 @@ closure_lookup_lfun_prog ( lfun_closure_t * l
 {
     int             ix;
     program_t      *prog;
+#ifdef DEBUG
     string_t       *obname;
+#endif
     Bool            is_inherited;
 
     is_inherited = MY_FALSE;
@@ -5873,13 +5875,17 @@ closure_lookup_lfun_prog ( lfun_closure_t * l
 
             /* Find the true definition of the function */
             prog = ob->prog;
+#ifdef DEBUG
             obname = ob->name;
+#endif
             break;
         }
 
         case T_LWOBJECT:
             prog = l->fun_ob.u.lwob->prog;
+#ifdef DEBUG
             obname = prog->name;
+#endif
             break;
 
         case T_NUMBER:

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -20083,7 +20083,9 @@ apply_prog (string_t *fun, program_t *progp, svalue_t ob, int num_arg, bool b_ig
  * left on the stack.
  */
 {
+#ifdef DEBUG
     struct control_stack *save_csp;
+#endif
     bytecode_p funstart;
     int fx;
 
@@ -20237,7 +20239,9 @@ apply_prog (string_t *fun, program_t *progp, svalue_t ob, int num_arg, bool b_ig
 
     previous_ob = current_object;
     current_object = ob;
+#ifdef DEBUG
     save_csp = csp;
+#endif
     eval_instruction(inter_pc, inter_sp);
 #ifdef DEBUG
     if (save_csp-1 != csp)
@@ -20388,7 +20392,9 @@ retry_for_shadow:
         goto retry_for_shadow;
     }
 
+#ifdef DEBUG
 failure:
+#endif
     if (get_txt(fun)[0] == ':')
         errorf("Illegal function call\n");
 

--- a/src/mempools.c
+++ b/src/mempools.c
@@ -77,9 +77,7 @@
 
 #include "mempools.h"
 #include "gcollect.h"
-#ifdef DEBUG
 #include "simulate.h"
-#endif
 #include "strfuns.h"
 #include "svalue.h"
 #include "xalloc.h"


### PR DESCRIPTION
Building with `enable_debug=no` fails on current compilers, since CI always builds with the default settings (DEBUG enabled) and the non-DEBUG configuration has rotted:

* `mempools.c` calls `fatal()` in `mempools_driver_info()` unconditionally, but includes `simulate.h` - which declares it - only in DEBUG builds. The resulting implicit function declaration is a hard error with GCC 14 and Clang 16 or newer.
* `apply_prog()` sets `save_csp`, `apply_low()` defines the label `failure`, and `closure_lookup_lfun_prog()` sets `obname` solely for consistency checks that are compiled only under DEBUG, drawing `-Wunused-but-set-variable`/`-Wunused-label` warnings in non-DEBUG builds.

`simulate.h` is now included unconditionally; the write-only variables and the orphaned label move under `#ifdef DEBUG`.

Both configurations build warning-free with this change and the test suite passes with the default configuration; the non-DEBUG driver was additionally smoke-tested against the test mudlib. (The suite's `--check-refcounts`/`--check-state 2` options need a DEBUG driver, so it cannot run unmodified against a non-DEBUG build.)
