### PR TITLE
driver: handle low-level I/O errors

### DIFF
--- a/src/access_check.c
+++ b/src/access_check.c
@@ -346,7 +346,8 @@ read_access_file (void)
 
             for (;;) {
                 c = 'm';
-                fscanf(infp, "%c %1[=]", &c, c2);
+                if (fscanf(infp, "%c %1[=]", &c, c2) < 1)
+                    c = 'm';
                 switch(c)
                 {
                 case 'w':
@@ -366,7 +367,9 @@ read_access_file (void)
                             break;
                         if (*c2 == '-') {
                             k = 24;
-                            fscanf(infp, "%d %1[,:] ", &k, c2);
+                            if (fscanf(infp, "%d %1[,:] ", &k, c2) < 1)
+                                break;
+
                             if (j <= k) {
                                 mask |= (2 << k) - (1 << j);
                             } else {
@@ -393,7 +396,8 @@ read_access_file (void)
 
         /* The rest of the line is the message to print.
          */
-        fgets(message, (int)sizeof(message)-1, infp);
+        if (fgets(message, (int)sizeof(message)-1, infp) == NULL)
+            message[0] = '\0';
         message[sizeof(message) - 1] = '\0';
 
         /* Check if this rule creates a new class. If yes, allocate

--- a/src/backend.c
+++ b/src/backend.c
@@ -836,7 +836,7 @@ backend (void)
                              , slow_shut_down_to_do
                              , (long)(time_now - time_last_gc)
                              );
-                  write(1, buf, strlen(buf));
+                  writes(1, buf);
                   command_giver = NULL;
                   clear_current_object();
                   /* if the GC was not requested by an efun call, low_memory()
@@ -855,7 +855,7 @@ backend (void)
                              , gc_request == gcEfun ? "efun" : "allocator"
                              , slow_shut_down_to_do
                              , (long)(time_now - time_last_gc));
-                  write(1, buf, strlen(buf));
+                  writes(1, buf);
                   reallocate_reserved_areas();
                 }
 
@@ -874,7 +874,7 @@ backend (void)
                         time_last_slow_shut = time_now;
                         malloc_privilege = MALLOC_MASTER;
                         sprintf(shut_msg, "%s slow_shut_down(%d)\n", time_stamp(), minutes);
-                        write(1, shut_msg, strlen(shut_msg));
+                        writes(1, shut_msg);
 
                         previous_ob = const0;
                         command_giver = NULL;
@@ -888,7 +888,7 @@ backend (void)
                         sprintf(buf, "%s Last slow_shut_down() still pending.\n"
                                    , time_stamp()
                                );
-                        write(1, buf, strlen(buf));
+                        writes(1, buf);
                     }
                 }
                 malloc_privilege = MALLOC_USER;

--- a/src/comm.c
+++ b/src/comm.c
@@ -868,6 +868,34 @@ set_socket_nonblocking (SOCKET_T new_socket)
 
 /*-------------------------------------------------------------------------*/
 static void
+write_socket_best_effort (SOCKET_T socket, const char *message, size_t length)
+
+/* Write as much of <message> as the nonblocking <socket> currently accepts.
+ * Retry interrupted writes and stop on any other error.
+ */
+
+{
+    int retries = 6;
+
+    while (length > 0)
+    {
+        ssize_t written = (ssize_t)socket_write(socket, message, length);
+
+        if (written > 0)
+        {
+            message += written;
+            length -= written;
+            retries = 6;
+        }
+        else if (written < 0 && errno == EINTR && --retries > 0)
+            continue;
+        else
+            break;
+    }
+} /* write_socket_best_effort() */
+
+/*-------------------------------------------------------------------------*/
+static void
 set_close_on_exec (SOCKET_T new_socket)
 
 /* Set that <new_socket> is closed when the driver performs an exec()
@@ -1291,7 +1319,7 @@ urgent_data_handler (int signo)
 
 {
     if (d_flag)
-        write(2, "received urgent data\n", 21);
+        write_bytes(2, "received urgent data\n", 21);
     urgent_data = MY_TRUE;
     urgent_data_time = current_time;
 }
@@ -2865,10 +2893,10 @@ get_message (char *buff, size_t *bufflength)
                     char buf[MAX_TEXT];
 #ifdef USE_TLS
                     if (ip->tls_status != TLS_INACTIVE)
-                        tls_read(ip, buf, MAX_TEXT);
+                        l = tls_read(ip, buf, MAX_TEXT);
                     else
 #endif
-                        socket_read(ip->socket, buf, MAX_TEXT);
+                        l = socket_read(ip->socket, buf, MAX_TEXT);
 
                     continue;
                 }
@@ -3304,7 +3332,8 @@ remove_interactive (object_t *ob, Bool force)
 
         erq_demon = interactive->socket;
         erq_proto_demon = -1;
-        socket_write(erq_demon, erq_welcome, sizeof erq_welcome);
+        write_socket_best_effort(erq_demon, (char *)erq_welcome,
+                                 sizeof erq_welcome);
     }
     else
 #endif
@@ -3581,8 +3610,8 @@ new_player ( object_t *ob, SOCKET_T new_socket
 
     if (message)
     {
-        socket_write(new_socket, message, strlen(message));
-        socket_write(new_socket, "\r\n", 2);
+        write_socket_best_effort(new_socket, message, strlen(message));
+        write_socket_best_effort(new_socket, "\r\n", 2);
         socket_close(new_socket);
         return;
     }
@@ -3601,12 +3630,12 @@ new_player ( object_t *ob, SOCKET_T new_socket
             string_t *msg;
 
             msg = driver_hook[H_NO_IPC_SLOT].u.str;
-            socket_write(new_socket, get_txt(msg), mstrsize(msg));
+            write_socket_best_effort(new_socket, get_txt(msg), mstrsize(msg));
         }
         else
         {
             message = "The mud is full. Come back later.\r\n";
-            socket_write(new_socket, message, strlen(message));
+            write_socket_best_effort(new_socket, message, strlen(message));
         }
         socket_close(new_socket);
         debug_message("%s Out of IPC slots for new connection.\n"
@@ -3619,7 +3648,7 @@ new_player ( object_t *ob, SOCKET_T new_socket
     if (O_IS_INTERACTIVE(master_ob))
     {
         message = "Cannot accept connections. Come back later.\r\n";
-        socket_write(new_socket, message, strlen(message));
+        write_socket_best_effort(new_socket, message, strlen(message));
         socket_close(new_socket);
         debug_message("%s Master still busy with previous new connection.\n"
                      , time_stamp());
@@ -3632,7 +3661,7 @@ new_player ( object_t *ob, SOCKET_T new_socket
     if (!new_interactive)
     {
         message = "Cannot accept connection (out of memory). Come back later.\r\n";
-        socket_write(new_socket, message, strlen(message));
+        write_socket_best_effort(new_socket, message, strlen(message));
         socket_close(new_socket);
         debug_message("%s Out of memory (%zu bytes) for new connection.\n"
                      , time_stamp(), sizeof(interactive_t));
@@ -3721,7 +3750,7 @@ new_player ( object_t *ob, SOCKET_T new_socket
             debug_message("%s Error setting up initial encoding: %s.\n", time_stamp(), strerror(errno));
 
         message = "Error setting up encoding.\r\n";
-        socket_write(new_socket, message, strlen(message));
+        write_socket_best_effort(new_socket, message, strlen(message));
         socket_close(new_socket);
 
         O_GET_INTERACTIVE(master_ob) = NULL;
@@ -5752,6 +5781,7 @@ start_erq_demon (const char *suffix, size_t suffixlen)
     int sockets[2];
     int pid, i;
     char c = 0;
+    ssize_t received;
 
     /* Create the freelist in pending_erq[] */
     pending_erq[0].fun.type = T_INVALID;
@@ -5787,8 +5817,12 @@ start_erq_demon (const char *suffix, size_t suffixlen)
     if ((pid = fork()) == 0)
     {
         /* Child */
-        dup2(sockets[0], 0);
-        dup2(sockets[0], 1);
+        if (dup2(sockets[0], 0) < 0 || dup2(sockets[0], 1) < 0)
+        {
+            write_bytes(sockets[0], "0", 1);
+            _exit(1);
+        }
+
         close(sockets[0]);
         close(sockets[1]);
 
@@ -5800,7 +5834,7 @@ start_erq_demon (const char *suffix, size_t suffixlen)
             else
                 execl((char *)path, "erq", "--forked", (char*)0);
         }
-        write(1, "0", 1);  /* indicate failure back to the driver */
+        write_bytes(1, "0", 1);  /* indicate failure back to the driver */
         _exit(1);
     }
 
@@ -5827,8 +5861,11 @@ start_erq_demon (const char *suffix, size_t suffixlen)
     /* Read the first character from the ERQ. If it's '0', the ERQ
      * didn't start.
      */
-    read(sockets[1], &c, 1);
-    if (c == '0') {
+    do
+        received = read(sockets[1], &c, 1);
+    while (received < 0 && errno == EINTR);
+
+    if (received != 1 || c == '0') {
         close(sockets[1]);
 
         printf("%s Failed to start erq.\n", time_stamp());

--- a/src/files.c
+++ b/src/files.c
@@ -244,13 +244,62 @@ struct xdirect
     int   mode;
 };
 
-#define XOPENDIR(dest, path) (\
-    (!chdir(path) &&\
-    NULL != ((dest) = opendir("."))) ||\
-        (chdir(mud_lib),MY_FALSE)\
-)
+/*-------------------------------------------------------------------------*/
+static void
+restore_mudlib_directory (void)
 
-#define xclosedir(dir_ptr)   (chdir(mud_lib),closedir(dir_ptr))
+/* Restore the process working directory after directory operations.
+ */
+
+{
+    if (chdir(mud_lib) < 0)
+        fatal("Could not restore mudlib directory '%s': %s.\n",
+              mud_lib, strerror(errno));
+} /* restore_mudlib_directory() */
+
+/*-------------------------------------------------------------------------*/
+static Bool
+xopendir (DIR **dest, const char *path)
+
+/* Change into <path> and open it. On failure, restore the mudlib working
+ * directory and preserve the original error.
+ */
+
+{
+    int errorno;
+
+    if (chdir(path) < 0)
+    {
+        errorno = errno;
+    }
+    else
+    {
+        *dest = opendir(".");
+        if (*dest != NULL)
+            return MY_TRUE;
+        errorno = errno;
+    }
+
+    restore_mudlib_directory();
+    errno = errorno;
+    return MY_FALSE;
+} /* xopendir() */
+
+/*-------------------------------------------------------------------------*/
+static void
+xclosedir (DIR *dir_ptr)
+
+/* Restore the mudlib working directory and close <dir_ptr>.
+ */
+
+{
+    restore_mudlib_directory();
+    if (closedir(dir_ptr) < 0)
+        debug_message("%s Could not close directory: %s.\n",
+                      time_stamp(), strerror(errno));
+} /* xclosedir() */
+
+#define XOPENDIR(dest, path) xopendir(&(dest), path)
 #define xrewinddir(dir_ptr)  rewinddir(dir_ptr)
 #define XDIR DIR
 
@@ -2030,8 +2079,19 @@ v_write_file (svalue_t *sp, int num_arg)
                     atend = true;
                 }
 
-                if (outbufptr != outbuf)
-                    fwrite(outbuf, outbufptr - outbuf, 1, f);
+                if (outbufptr != outbuf
+                 && fwrite(outbuf, outbufptr - outbuf, 1, f) != 1)
+                {
+                    int err = errno;
+
+                    mb_free(mbFile);
+                    fclose(f);
+                    if (err)
+                        errorf("Could not write file: (%d) %s.\n",
+                               err, strerror(err));
+                    else
+                        errorf("Could not write complete file contents.\n");
+                }
 
                 if (res == (size_t)-1)
                 {

--- a/src/gcollect.c
+++ b/src/gcollect.c
@@ -2767,12 +2767,12 @@ show_string (int d, char *block, int depth UNUSED)
         WRITES(d, "\"");
         if ((len = strlen(block)) < 70)
         {
-            write(d, block, len);
+            write_bytes(d, block, len);
             WRITES(d, "\"");
         }
         else
         {
-            write(d, block, 50);
+            write_bytes(d, block, 50);
             WRITES(d, "\" (truncated, length ");writed(d, len);WRITES(d, ")");
         }
     }
@@ -2797,12 +2797,12 @@ show_mstring_data (int d, void *block, int depth UNUSED)
     WRITES(d, ")\"");
     if (str->size < 50)
     {
-        write(d, str->txt, str->size);
+        write_bytes(d, str->txt, str->size);
         WRITES(d, "\"");
     }
     else
     {
-        write(d, str->txt, 50);
+        write_bytes(d, str->txt, 50);
         WRITES(d, "\" (truncated)");
     }
 } /* show_mstring_data() */

--- a/src/main.c
+++ b/src/main.c
@@ -818,6 +818,35 @@ debug_message(const char *a, ...)
 
 /*-------------------------------------------------------------------------*/
 void
+write_bytes (int d, const char *s, size_t length)
+
+/* Memory-safe best-effort function to write <length> bytes from <s> to
+ * descriptor <d>. Complete partial writes and retry interrupted writes.
+ */
+
+{
+    int saved_errno = errno;
+
+    while (length > 0)
+    {
+        ssize_t written = write(d, s, length);
+
+        if (written > 0)
+        {
+            s += written;
+            length -= written;
+        }
+        else if (written < 0 && errno == EINTR)
+            continue;
+        else
+            break;
+    }
+
+    errno = saved_errno;
+} /* write_bytes() */
+
+/*-------------------------------------------------------------------------*/
+void
 write_x (int d, p_uint i)
 
 /* Memory safe function to write 4-byte hexvalue <i> to fd <d>. */
@@ -830,7 +859,7 @@ write_x (int d, p_uint i)
         c = (char)((i >> (8 * sizeof i - 4) ) + '0');
         if (c >= '9' + 1)
             c += (char)('a' - ('9' + 1));
-        write(d, &c, 1);
+        write_bytes(d, &c, 1);
     }
 } /* write_x() */
 
@@ -848,7 +877,7 @@ write_X (int d, unsigned char i)
         c = (char)((i >> (8 * sizeof i - 4) ) + '0');
         if (c >= '9' + 1)
             c += (char)('a' - ('9' + 1));
-        write(d, &c, 1);
+        write_bytes(d, &c, 1);
     }
 } /* write_X() */
 
@@ -866,7 +895,7 @@ writed (int d, p_uint i)
     if (!j) j = 1;
     do {
         c = (char)((i / j) % 10 + '0');
-        write(d, &c, 1);
+        write_bytes(d, &c, 1);
         j /= 10;
     } while (j > 0);
 } /* writed() */
@@ -878,7 +907,7 @@ writes (int d, const char *s)
 /* Memory safe function to string <s> to fd <d>. */
 
 {
-    write(d, s, strlen(s));
+    write_bytes(d, s, strlen(s));
 }
 
 /*-------------------------------------------------------------------------*/
@@ -899,23 +928,23 @@ dprintf_first (int fd, char *s, p_int a)
     do {
         if ( !(p = strchr(s, '%')) )
         {
-            write(fd, s, strlen(s));
+            writes(fd, s);
             return "";
         }
 
-        write(fd, s, p - s);
+        write_bytes(fd, s, p - s);
         switch(p[1])
         {
         case '%':
-            write(fd, p+1, 1);
+            write_bytes(fd, p+1, 1);
             continue;
         case 's':
-            write(fd, (char *)a, strlen((char*)a));
+            writes(fd, (char *)a);
             break;
         case 'c':
           {
             char c = (char)a;
-            write(fd, (char *)&c, 1);
+            write_bytes(fd, (char *)&c, 1);
             break;
           }
         case 'd':
@@ -942,7 +971,7 @@ dprintf1 (int fd, char *s, p_int a)
 
 {
     s = dprintf_first(fd, s, a);
-    write(fd, s, strlen(s));
+    writes(fd, s);
 } /* dprintf1() */
 
 /*-------------------------------------------------------------------------*/
@@ -3028,8 +3057,15 @@ eval_arg (int eOption, const char * pValue)
             int n;
 
             n = strtol(pValue, (char **)0, 0);
-            while(--n >= 0) {
-                (void)dup(2);
+            while (--n >= 0)
+            {
+                if (dup(2) < 0)
+                {
+                    fprintf(stderr,
+                            "Could not gobble another file descriptor: %s.\n",
+                            strerror(errno));
+                    return hrError;
+                }
             }
             break;
         }

--- a/src/main.h
+++ b/src/main.h
@@ -61,6 +61,7 @@ extern void initialize_master_uid(void);
 extern void debug_message(const char *, ...) FORMATDEBUG(printf, 1, 2);
 extern void vdebug_message(const char *, va_list) FORMATDEBUG(printf, 1, 0);
 
+extern void write_bytes(int d, const char *s, size_t length);
 extern void write_X (int d, unsigned char i);
 extern void write_x(int d, p_uint i);
 extern void writed(int d, p_uint i);

--- a/src/make_func.y
+++ b/src/make_func.y
@@ -2763,7 +2763,8 @@ yylex1 (void)
             int line;
             char file[MAXPATHLEN+1];
 
-            fgets(line_buffer, MAKE_FUNC_MAXLINE, fpr);
+            if (fgets(line_buffer, MAKE_FUNC_MAXLINE, fpr) == NULL)
+                yyerror("End of file after '#' directive");
             if ( sscanf(line_buffer, "%d \"%s\"",&line,file ) == 2 )
             {
                 current_line = line+1;
@@ -2798,7 +2799,8 @@ yylex1 (void)
                 return END;
             }
             send_end = 1;
-            fgets(line_buffer, MAKE_FUNC_MAXLINE, fpr);
+            if (fgets(line_buffer, MAKE_FUNC_MAXLINE, fpr) == NULL)
+                yyerror("End of file after '%' directive");
             current_line++;
             if (parsetype == PARSE_FUNC_SPEC)
             {

--- a/src/slaballoc.c
+++ b/src/slaballoc.c
@@ -446,7 +446,7 @@ static word_t samagic[]
 
 #ifdef DEBUG_MALLOC_ALLOCS
 #    define ulog(s) \
-       write(gcollect_outfd, s, strlen(s))
+       writes(gcollect_outfd, s)
 #    define ulog1f(s,t) \
        dprintf1(gcollect_outfd, s, (p_int)(t))
 #    define ulog2f(s,t1,t2) \

--- a/src/smalloc.c
+++ b/src/smalloc.c
@@ -475,7 +475,7 @@ static word_t samagic[]
 
 #ifdef DEBUG_MALLOC_ALLOCS
 #    define ulog(s) \
-       write(gcollect_outfd, s, strlen(s))
+       writes(gcollect_outfd, s)
 #    define ulog1f(s,t) \
        dprintf1(gcollect_outfd, s, (p_int)(t))
 #    define ulog2f(s,t1,t2) \

--- a/src/swap.c
+++ b/src/swap.c
@@ -2296,7 +2296,8 @@ load_ob_from_swap (object_t *ob)
             return result | -0x80;
         }
 
-        fread(block, size, 1, swap_file);
+        if (size > 0 && fread(block, size, 1, swap_file) != 1)
+            fatal("Couldn't read the swap file.\n");
 
         /* Prepare to restore */
         set_current_object(&dummy);
@@ -2406,8 +2407,9 @@ load_line_numbers_from_swap (program_t *prog)
 
     if (tmp_numbers.size > sizeof(tmp_numbers))
     {
-        fread(lines+1, tmp_numbers.size - sizeof(tmp_numbers)
-             , 1, swap_file);
+        if (fread(lines+1, tmp_numbers.size - sizeof(tmp_numbers),
+                  1, swap_file) != 1)
+            fatal("Couldn't read the swap file.\n");
     }
 
     prog->line_numbers = lines;

--- a/src/xalloc.c
+++ b/src/xalloc.c
@@ -22,6 +22,7 @@
 #include "backend.h"
 #include "gcollect.h"
 #include "interpret.h"
+#include "main.h"
 #include "simulate.h"
 
 #include "exec.h"
@@ -1059,7 +1060,7 @@ print_block (int d, word_t *block)
          && dispatch_table[i].line == line)
         {
             (*dispatch_table[i].func)(d, (char *)(block+XM_OVERHEAD), 0);
-            write(d, "\n", 1);
+            write_bytes(d, "\n", 1);
             return;
         }
     }
@@ -1092,7 +1093,7 @@ print_block (int d, word_t *block)
             for (i = 0; i < 16 && i < (int)size && i < limit; i++)
             {
                 if (isprint((unsigned char)cp[i]))
-                    write(d, cp+i, 1);
+                    write_bytes(d, cp+i, 1);
                 else
                     writes(d, ".");
             }
@@ -1655,7 +1656,6 @@ reallocate_reserved_areas (void)
  */
 
 {
-    char *p;
     malloc_privilege = MALLOC_USER;
     if (reserved_system_size && !reserved_system_area) {
         if ( !(reserved_system_area = xalloc((size_t)reserved_system_size)) ) {
@@ -1663,8 +1663,7 @@ reallocate_reserved_areas (void)
             return;
         }
         else {
-            p = "Reallocated System reserve.\n";
-            write(1, p, strlen(p));
+            writes(1, "Reallocated System reserve.\n");
         }
     }
     if (reserved_master_size && !reserved_master_area) {
@@ -1673,8 +1672,7 @@ reallocate_reserved_areas (void)
             return;
         }
         else {
-            p = "Reallocated Master reserve.\n";
-            write(1, p, strlen(p));
+            writes(1, "Reallocated Master reserve.\n");
         }
     }
     if (reserved_user_size && !reserved_user_area) {
@@ -1683,8 +1681,7 @@ reallocate_reserved_areas (void)
             return;
         }
         else {
-            p = "Reallocated User reserve.\n";
-            write(1, p, strlen(p));
+            writes(1, "Reallocated User reserve.\n");
         }
     }
     slow_shut_down_to_do = 0;


### PR DESCRIPTION
## Summary

- add a helper that completes descriptor writes and handles interrupted writes
- check and report failures in low-level startup, file, directory, swap, garbage collection, and ERQ I/O paths
- preserve errno where logging or cleanup could otherwise obscure the original failure