### PR TITLE
Fix corruption/crash from stale break_sp in resumed coroutines

### DIFF
--- a/src/coroutine.c
+++ b/src/coroutine.c
@@ -176,6 +176,7 @@ create_coroutine (svalue_t *closure)
     result->pc = inter_pc + 1 + 2*result->num_variable_names;
     result->function_index_offset = function_index_offset;
     result->variable_index_offset = variable_index_offset;
+    result->num_break_addrs = 0;
     reference_prog(result->prog, "create_coroutine");
 
     result->state = CS_SLEEPING;
@@ -224,6 +225,13 @@ suspend_coroutine (coroutine_t *cr, svalue_t *fp)
     /* Now save the pc and the stack. */
     num_values = inter_sp - fp + 1 - cr->num_variables;
     assert(num_values >= 0);
+
+    /* The compiler includes the maximum break stack depth in
+     * num_variables. Its entries are saved with the locals, and only the
+     * current depth needs to be recorded to restore break_sp later.
+     */
+    cr->num_break_addrs = (fp + cr->num_variables) - break_sp;
+    assert(cr->num_break_addrs >= 0 && cr->num_break_addrs <= cr->num_variables);
 
     if (num_values > CR_RESERVED_EXTRA_VALUES)
     {
@@ -379,6 +387,10 @@ resume_coroutine (coroutine_t *cr)
 
     for (int i = 0; i < cr->num_variables; i++)
         transfer_svalue_no_free(++inter_sp, cr->variables + i);
+
+    /* Rebase the saved break stack depth onto the restored frame. */
+    break_sp = inter_sp + 1 - cr->num_break_addrs;
+
     for (int i = 0; i < cr->num_values; i++)
     {
         transfer_svalue_no_free(++inter_sp, extra + i);

--- a/src/coroutine.h
+++ b/src/coroutine.h
@@ -81,6 +81,7 @@ struct coroutine_s
     int num_variables;              /* Number of local variables.     */
     int num_values;                 /* Number of extra values.        */
     int num_variable_names;         /* Number of variable names.      */
+    int num_break_addrs;            /* Current break stack depth.      */
 #ifdef DEBUG
     int num_hidden_variables;       /* Number of hidden temporary
                                      * variables (eg. in a foreach.

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -473,7 +473,7 @@ svalue_t *inter_context;
    * May be NULL if no context is available.
    */
 
-static svalue_t *break_sp;
+svalue_t *break_sp;
   /* Points to address to branch to at next F_BREAK from within a switch().
    * This is actually a stack of addresses with break_sp pointing to the
    * bottom with the most recent entry. This break stack is stored on

--- a/src/interpret.h
+++ b/src/interpret.h
@@ -208,6 +208,7 @@ extern struct control_stack *csp;
 extern svalue_t * inter_fp;
 extern svalue_t * inter_sp;
 extern svalue_t * inter_context;
+extern svalue_t * break_sp;
 extern int function_index_offset;
 extern int variable_index_offset;
 extern svalue_t *current_variables;

--- a/test/t-coroutine/master.c
+++ b/test/t-coroutine/master.c
@@ -221,6 +221,101 @@ void run_test()
                 return 1;
             },
         }),
+        ({ "switch after yield", 0,
+            function int()
+            {
+                coroutine cr = async function int()
+                {
+                    int result;
+
+                    while (1)
+                    {
+                        mixed v = yield(result);
+                        switch (v)
+                        {
+                            case 1: result += 10; break;
+                            case 2: result += 20; break;
+                            default: return result;
+                        }
+                    }
+                };
+                /* If break_sp is not restored, the resumed coroutine writes
+                 * its break address into this frame's last local.
+                 */
+                int sentinel = 42;
+
+                if (call_coroutine(cr) != 0)
+                    return 0;
+                if (call_coroutine(cr, 1) != 10)
+                    return 0;
+                if (call_coroutine(cr, 2) != 30)
+                    return 0;
+                if (call_coroutine(cr, 3) != 30)
+                    return 0;
+                return sentinel == 42 && !cr;
+            },
+        }),
+        ({ "yield within switch", 0,
+            function int()
+            {
+                coroutine cr = async function int()
+                {
+                    int result;
+
+                    for (int i = 1; i <= 3; i++)
+                    {
+                        switch (i)
+                        {
+                            case 1:  result += yield(1); break;
+                            case 2:  result += yield(2); break;
+                            default: result += yield(i); break;
+                        }
+                    }
+                    return result;
+                };
+
+                if (call_coroutine(cr) != 1)
+                    return 0;
+                if (call_coroutine(cr, 100) != 2)
+                    return 0;
+                if (call_coroutine(cr, 200) != 3)
+                    return 0;
+                if (call_coroutine(cr, 300) != 600)
+                    return 0;
+                return !cr;
+            },
+        }),
+        ({ "continue within switch after yield", 0,
+            function int()
+            {
+                coroutine cr = async function int()
+                {
+                    int result;
+
+                    for (int i = 0; i < 4; i++)
+                    {
+                        switch (yield(i))
+                        {
+                            case 0:  continue;
+                            default: result += i;
+                        }
+                    }
+                    return result;
+                };
+
+                if (call_coroutine(cr) != 0)
+                    return 0;
+                if (call_coroutine(cr, 0) != 1)
+                    return 0;
+                if (call_coroutine(cr, 1) != 2)
+                    return 0;
+                if (call_coroutine(cr, 0) != 3)
+                    return 0;
+                if (call_coroutine(cr, 1) != 4)
+                    return 0;
+                return !cr;
+            },
+        }),
         ({ "driver_info(DI_NUM_COROUTINES) after some tests", 0,
             function int()
             {

--- a/test/t-python/master.c
+++ b/test/t-python/master.c
@@ -520,6 +520,7 @@ void run_test()
             start_gc(function void(int result)
             {
                 mixed val = python_get();
+                mixed* hook_info = python_get_hook_info();
 
                 if (result)
                 {
@@ -548,9 +549,16 @@ void run_test()
 
                 python_set(0);
 
-                if(python_get_hook_info()[0] == 0)
+                if(hook_info[0] == 0)
                 {
                     msg("Heartbeat hook didn't count any heartbeats!\n");
+                    shutdown(1);
+                    return;
+                }
+
+                if(!hook_info[2])
+                {
+                    msg("Python heartbeat coroutine switch test failed!\n");
                     shutdown(1);
                     return;
                 }

--- a/test/t-python/startup.py
+++ b/test/t-python/startup.py
@@ -2021,9 +2021,15 @@ ldmud.register_efun("unregister_abs", lambda: ldmud.unregister_efun("abs"))
 
 # Test of the hooks
 num_hb = 0
+external_coroutine_result = None
 def hb_hook():
-    global num_hb
+    global num_hb, external_coroutine_result
     num_hb += 1
+
+    if external_coroutine_result is None:
+        # Exercise coroutine resumption with no active LPC frame.
+        cr = ldmud.LWObject("/testob").functions.test_switch_coroutine()
+        external_coroutine_result = cr() == 0 and cr(1) == 42 and not cr
 
 ob_list = []
 def ob_created(ob):
@@ -2033,7 +2039,7 @@ def ob_destroyed(ob):
     ob_list.remove(ob)
 
 def get_hook_info():
-    return ldmud.Array((num_hb, ldmud.Array(ob_list),))
+    return ldmud.Array((num_hb, ldmud.Array(ob_list), external_coroutine_result))
 
 last_progname = None
 last_filename = None

--- a/test/t-python/testob.c
+++ b/test/t-python/testob.c
@@ -28,6 +28,17 @@ async string* testcoroutine(varargs string* args)
     return args + ({ yield(sizeof(args)), local });
 }
 
+async int test_switch_coroutine()
+{
+    mixed value = yield(0);
+
+    switch (value)
+    {
+        case 1:  return 42;
+        default: return 0;
+    }
+}
+
 mixed callback(closure fun)
 {
     return funcall(fun);


### PR DESCRIPTION
Previously coroutines preserved their locals, temp values, and program counter across suspension and resume but they did not preserve `break_sp`, the interpreter break-stack pointer.

`setup_new_frame2()` normally initializes `break_sp` for a new LPC frame, but `f_call_coroutine()` resumes a coroutine directly. As a result coroutines inherited the resumer's `break_sp`.

`F_SWITCH` pushes a continuation onto the break stack, while `F_BREAK` and switch-aware continue instructions consume it. If `break_sp` isn't saved/restored after a `yield`, these operations could use the wrong stack and corrupt the resumer's frame, or dereference `NULL` and crash when resumed from external Python that doesn't have an active LPC frame (this is what I bumped into :laughing: :boom: ).

The compiler includes the maximum break stack depth in the function local-variable count, so the `T_BREAK_ADDR` entries are already saved and restored with the coroutine locals. We just need to record the current depth on suspend and rebase `break_sp` onto the restored frame on resume to fix the issue.